### PR TITLE
Add glog for logging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,10 @@ Fix format error in-place
 buildifier -showlog -mode=fix $(find . -type f \( -iname BUILD -or -iname BUILD.bazel \))
 ```
 
+## Logging
+We use [google/glog](https://github.com/google/glog) for logging. See [documentation](http://rpg.ifi.uzh.ch/docs/glog.html).
+The log message will be logged to `/tmp/<program name>.<hostname>.<user name>.log.<severity level>.<date>.<time>.<pid>`. (e.g., "/tmp/hello_world.example.com.hamaji.log.INFO.20080709-222411.10474")
+
 ## TODO
 
 * [x] lint
@@ -82,14 +86,14 @@ buildifier -showlog -mode=fix $(find . -type f \( -iname BUILD -or -iname BUILD.
 * [ ] coverage report
     * coveralls/codecov
 * [ ] documentation
-        * sphinx
+    * sphinx
 * [ ] API document
-        * doxygen + sphinx
+    * doxygen + sphinx
 * [ ] benchmarking
-        * [google/benchmark: A microbenchmark support library](https://github.com/google/benchmark)
+    * [google/benchmark: A microbenchmark support library](https://github.com/google/benchmark)
 * [ ] checking memory leak
     * valgrind
-* [ ] logging
+* [x] logging
     * [google/glog: C\+\+ implementation of the Google logging module](https://github.com/google/glog)
 * [ ] packaging
 * CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,13 @@ To format all of code in the repository, you can run the script on the root of t
 Check whether format error exists or not
 
 ```
-buildifier -showlog -mode=check $(find . -type f \( -iname BUILD -or -iname BUILD.bazel \))
+buildifier -showlog -mode=check $(find . -type f -name BUILD -or -name 'BUILD.*' -or -name BUILD.bazel)
 ```
 
 Fix format error in-place
 
 ```
-buildifier -showlog -mode=fix $(find . -type f \( -iname BUILD -or -iname BUILD.bazel \))
+buildifier -showlog -mode=fix $(find . -type f -name BUILD -or -name 'BUILD.*' -or -name BUILD.bazel)
 ```
 
 ## Logging

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,10 @@
+# for glog
+git_repository(
+    name   = "com_github_gflags_gflags",
+    commit = "f8a0efe03aa69b3336d8e228b37d4ccb17324b88",
+    remote = "https://github.com/gflags/gflags.git",
+)
+
 # the glog files.
 # bazel build @glog//:glog
 new_git_repository(

--- a/recipe/util/BUILD
+++ b/recipe/util/BUILD
@@ -11,6 +11,7 @@ cc_library(
         "-std=c++11",
     ],
     deps = [
+        "@glog",
     ],
 )
 

--- a/recipe/util/main_test.cc
+++ b/recipe/util/main_test.cc
@@ -1,0 +1,9 @@
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  ::testing::InitGoogleTest(&argc, argv);
+  FLAGS_log_dir = "/tmp";
+  return RUN_ALL_TESTS();
+}

--- a/recipe/util/sample.cc
+++ b/recipe/util/sample.cc
@@ -1,7 +1,10 @@
 #include "recipe/util/sample.h"
+#include <glog/logging.h>
 
 namespace recipe {
 namespace util {
-int hoge() { return 1; }
+int hoge() {
+  LOG(INFO) << "file";
+  return 1; }
 }  // namespace util
 }  // namespace recipe

--- a/recipe/util/sample.cc
+++ b/recipe/util/sample.cc
@@ -5,6 +5,7 @@ namespace recipe {
 namespace util {
 int hoge() {
   LOG(INFO) << "file";
-  return 1; }
+  return 1;
+}
 }  // namespace util
 }  // namespace recipe


### PR DESCRIPTION
## Summary
This PR adds `google/glog` library for logging. See http://rpg.ifi.uzh.ch/docs/glog.html for the usage of `glog`.
This PR also includes some sample snippets of `glog` in `recipe/util`.
