### PR TITLE
Add benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 #
 # env
 # * BUILD_TYPE
-#   * Coverage
 #   * Debug
+#   * Release
+#
+# * BUILD_TARGET
+#   * comma separated values
+#   * available values are:
+#     * Coverage
+#     * Benchmark
+#   * e.g. BUILD_TARGET="Coverage,Benchmark"
 #
 sudo: required
 dist: trusty
@@ -13,7 +20,8 @@ matrix:
   - os: linux
     compiler: gcc
     env:
-    - BUILD_TYPE=Coverage
+    - BUILD_TYPE=Debug
+    - BUILD_TARGET=Coverage
     addons:
       apt:
         packages:
@@ -21,7 +29,8 @@ matrix:
   - os: linux
     compiler: gcc
     env:
-    - BUILD_TYPE=Debug
+    - BUILD_TYPE=Release
+    - BUILD_TARGET=Benchmark
     addons:
       apt:
         sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ matrix:
   - os: linux
     compiler: clang++
     env:
-    - BUILD_TYPE=Debug
+    - BUILD_TYPE=Release
+    - BUILD_TARGET=Benchmark
     addons:
       apt:
         sources:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,64 @@
 To build the library, you need to run
 
 ```
+bazel build //recipe/...
+```
+
+You can build only specific sub packages
+
+```
 bazel build //recipe/integrate:integrate
+bazel build //recipe/sandbox:sandbox
 bazel build //recipe/util:util
 ```
 
+Debug build
+
+```
+bazel build //recipe --compilation_mode=dbg
+```
+
 ## Test
-Run all tests
+We use gtest for testing. Take a look at official documents:
+
+* [Google test primer](https://github.com/google/googletest/blob/master/googletest/docs/primer.md)
+* [Gtest advanced document](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md)
+
+You can run all tests with command
 
 ```
 bazel test "//recipe/..."
 ```
 
+Executing tests for specific subpackages is also possible
+
 ```
 bazel test //recipe/integrate:test
+bazel build //recipe/sandbox:sandbox
 bazel test //recipe/util:test
 ```
 
+## Benchmark
+Run benchmarks with debug build options
+
+```
+bazel run --compilation_mode=dbg "//benchmark/..."
+```
+
+Run benchmarks with optimized(release) build options
+
+```
+bazel run --compilation_mode=opt "//benchmark/..."
+```
+
+If you want to run all benchmarks,
+
+```
+./tools/run_benchmark.sh
+```
+
 ## Formatter/Linter
+We follow [Google C\+\+ Style Guide](https://google.github.io/styleguide/cppguide.html).
 
 ### C++
 We use `clang-format` for formatting code.
@@ -89,7 +130,7 @@ The log message will be logged to `/tmp/<program name>.<hostname>.<user name>.lo
     * sphinx
 * [ ] API document
     * doxygen + sphinx
-* [ ] benchmarking
+* [x] benchmarking
     * [google/benchmark: A microbenchmark support library](https://github.com/google/benchmark)
 * [ ] checking memory leak
     * valgrind

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/i05nagai/numerical_recipe.svg?branch=master)](https://travis-ci.org/i05nagai/numerical_recipe)
 [![Coverage Status](https://coveralls.io/repos/github/i05nagai/numerical_recipe/badge.svg)](https://coveralls.io/github/i05nagai/numerical_recipe)
 
-## Compiler
+## Compiler Support
 * g++-4.9
 * clang-3.9

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,11 @@
-# for glog
+#
+# glog
+#
 git_repository(
     name   = "com_github_gflags_gflags",
     commit = "f8a0efe03aa69b3336d8e228b37d4ccb17324b88",
     remote = "https://github.com/gflags/gflags.git",
 )
-
 # the glog files.
 # bazel build @glog//:glog
 new_git_repository(
@@ -23,4 +24,17 @@ new_http_archive(
     url = "https://github.com/google/googletest/archive/release-1.8.0.zip",
     build_file = "//ci/bazel:BUILD.gtest",
     strip_prefix = "googletest-release-1.8.0/googletest",
+)
+
+#
+# google/benchmark
+#
+new_http_archive(
+    name = "benchmark",
+    build_file = "//ci/bazel:BUILD.benchmark",
+    sha256 = "f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d",
+    strip_prefix = "benchmark-1.4.1",
+    urls = [
+        "https://github.com/google/benchmark/archive/v1.4.1.tar.gz",
+    ],
 )

--- a/benchmark/recipe/integrate/BUILD
+++ b/benchmark/recipe/integrate/BUILD
@@ -1,0 +1,15 @@
+cc_binary(
+    name = "integrate",
+    srcs = glob([
+        "*.cc",
+        "*.h",
+    ]),
+    copts = [
+        "-std=c++11",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//recipe/integrate:integrate",
+        "@benchmark",
+    ],
+)

--- a/benchmark/recipe/integrate/BUILD
+++ b/benchmark/recipe/integrate/BUILD
@@ -9,7 +9,7 @@ cc_binary(
     ],
     linkstatic = 1,
     deps = [
-        "//recipe/integrate:integrate",
+        "//recipe/integrate",
         "@benchmark",
     ],
 )

--- a/benchmark/recipe/integrate/main.cc
+++ b/benchmark/recipe/integrate/main.cc
@@ -1,0 +1,7 @@
+#include <benchmark/benchmark.h>
+
+namespace recipe {
+namespace integrate {
+BENCHMARK_MAIN();
+} // namespace integrate
+} // namespace recipe

--- a/benchmark/recipe/integrate/main.cc
+++ b/benchmark/recipe/integrate/main.cc
@@ -3,5 +3,5 @@
 namespace recipe {
 namespace integrate {
 BENCHMARK_MAIN();
-} // namespace integrate
-} // namespace recipe
+}  // namespace integrate
+}  // namespace recipe

--- a/benchmark/recipe/integrate/sample.cc
+++ b/benchmark/recipe/integrate/sample.cc
@@ -3,15 +3,16 @@
 
 namespace recipe {
 namespace integrate {
-static void BenchmarkFoobar(benchmark::State& state)
-{
-  while(state.KeepRunning()) {
+static void BenchmarkFoobar(benchmark::State& state) {
+  while (state.KeepRunning()) {
     benchmark::DoNotOptimize(Foobar(state.range(0)));
   }
 }
+// clang-format off
 BENCHMARK(BenchmarkFoobar)
   ->Arg(100)
   ->Arg(1000)
   ->Arg(10000);
-} // namespace integrate
-} // namespace recipe
+// clang-format on
+}  // namespace integrate
+}  // namespace recipe

--- a/benchmark/recipe/integrate/sample.cc
+++ b/benchmark/recipe/integrate/sample.cc
@@ -1,0 +1,17 @@
+#include "recipe/integrate/sample.h"
+#include <benchmark/benchmark.h>
+
+namespace recipe {
+namespace integrate {
+static void BenchmarkFoobar(benchmark::State& state)
+{
+  while(state.KeepRunning()) {
+    benchmark::DoNotOptimize(Foobar(state.range(0)));
+  }
+}
+BENCHMARK(BenchmarkFoobar)
+  ->Arg(100)
+  ->Arg(1000)
+  ->Arg(10000);
+} // namespace integrate
+} // namespace recipe

--- a/benchmark/recipe/sandbox/BUILD
+++ b/benchmark/recipe/sandbox/BUILD
@@ -1,0 +1,15 @@
+cc_binary(
+    name = "sandbox",
+    srcs = glob([
+        "*.cc",
+        "*.h",
+    ]),
+    copts = [
+        "-std=c++11",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//recipe/sandbox:sandbox",
+        "@benchmark",
+    ],
+)

--- a/benchmark/recipe/sandbox/BUILD
+++ b/benchmark/recipe/sandbox/BUILD
@@ -9,7 +9,7 @@ cc_binary(
     ],
     linkstatic = 1,
     deps = [
-        "//recipe/sandbox:sandbox",
+        "//recipe/sandbox",
         "@benchmark",
     ],
 )

--- a/benchmark/recipe/sandbox/main.cc
+++ b/benchmark/recipe/sandbox/main.cc
@@ -1,0 +1,7 @@
+#include <benchmark/benchmark.h>
+
+namespace recipe {
+namespace sandbox {
+BENCHMARK_MAIN();
+} // namespace sandbox
+} // namespace recipe

--- a/benchmark/recipe/sandbox/main.cc
+++ b/benchmark/recipe/sandbox/main.cc
@@ -3,5 +3,5 @@
 namespace recipe {
 namespace sandbox {
 BENCHMARK_MAIN();
-} // namespace sandbox
-} // namespace recipe
+}  // namespace sandbox
+}  // namespace recipe

--- a/benchmark/recipe/sandbox/sample.cc
+++ b/benchmark/recipe/sandbox/sample.cc
@@ -1,0 +1,15 @@
+#include "recipe/sandbox/sample.h"
+#include <benchmark/benchmark.h>
+
+namespace recipe {
+namespace sandbox {
+static void BenchmarkFoo(benchmark::State& state)
+{
+  while(state.KeepRunning()) {
+    benchmark::DoNotOptimize(Foo());
+  }
+}
+BENCHMARK(BenchmarkFoo);
+} // namespace sandbox
+} // namespace recipe
+

--- a/benchmark/recipe/sandbox/sample.cc
+++ b/benchmark/recipe/sandbox/sample.cc
@@ -3,13 +3,11 @@
 
 namespace recipe {
 namespace sandbox {
-static void BenchmarkFoo(benchmark::State& state)
-{
-  while(state.KeepRunning()) {
+static void BenchmarkFoo(benchmark::State& state) {
+  while (state.KeepRunning()) {
     benchmark::DoNotOptimize(Foo());
   }
 }
 BENCHMARK(BenchmarkFoo);
-} // namespace sandbox
-} // namespace recipe
-
+}  // namespace sandbox
+}  // namespace recipe

--- a/benchmark/recipe/util/BUILD
+++ b/benchmark/recipe/util/BUILD
@@ -13,4 +13,3 @@ cc_binary(
         "@benchmark",
     ],
 )
-

--- a/benchmark/recipe/util/BUILD
+++ b/benchmark/recipe/util/BUILD
@@ -1,0 +1,16 @@
+cc_binary(
+    name = "util",
+    srcs = glob([
+        "*.cc",
+        "*.h",
+    ]),
+    copts = [
+        "-std=c++11",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//recipe/util",
+        "@benchmark",
+    ],
+)
+

--- a/benchmark/recipe/util/main.cc
+++ b/benchmark/recipe/util/main.cc
@@ -3,7 +3,5 @@
 namespace recipe {
 namespace util {
 BENCHMARK_MAIN();
-} // namespace util
-} // namespace recipe
-
-
+}  // namespace util
+}  // namespace recipe

--- a/benchmark/recipe/util/main.cc
+++ b/benchmark/recipe/util/main.cc
@@ -1,0 +1,9 @@
+#include <benchmark/benchmark.h>
+
+namespace recipe {
+namespace util {
+BENCHMARK_MAIN();
+} // namespace util
+} // namespace recipe
+
+

--- a/benchmark/recipe/util/sample.cc
+++ b/benchmark/recipe/util/sample.cc
@@ -1,0 +1,15 @@
+#include "recipe/util/sample.h"
+#include <benchmark/benchmark.h>
+
+namespace recipe {
+namespace util {
+static void BenchmarkBar(benchmark::State& state)
+{
+  while(state.KeepRunning()) {
+    benchmark::DoNotOptimize(Bar());
+  }
+}
+BENCHMARK(BenchmarkBar);
+} // namespace util
+} // namespace recipe
+

--- a/benchmark/recipe/util/sample.cc
+++ b/benchmark/recipe/util/sample.cc
@@ -3,13 +3,11 @@
 
 namespace recipe {
 namespace util {
-static void BenchmarkBar(benchmark::State& state)
-{
-  while(state.KeepRunning()) {
+static void BenchmarkBar(benchmark::State& state) {
+  while (state.KeepRunning()) {
     benchmark::DoNotOptimize(Bar());
   }
 }
 BENCHMARK(BenchmarkBar);
-} // namespace util
-} // namespace recipe
-
+}  // namespace util
+}  // namespace recipe

--- a/ci/bazel/BUILD.benchmark
+++ b/ci/bazel/BUILD.benchmark
@@ -1,14 +1,18 @@
 cc_library(
     name = "benchmark",
-    srcs = glob(["src/*.cc"],
-                exclude = ["src/re_posix.cc", "src/gnuregex.cc"]),
-    hdrs = glob(["src/*.h", "include/benchmark/*.h"],
-                exclude = ["src/re_posix.h", "src/gnuregex.h"]),
+    srcs = glob(
+        ["src/*.cc"],
+        exclude = ["src/re_posix.cc", "src/gnuregex.cc"],
+    ),
+    hdrs = glob(
+        ["src/*.h", "include/benchmark/*.h"],
+        exclude = ["src/re_posix.h", "src/gnuregex.h"],
+    ),
     includes = [
-         "include",
+        "include",
     ],
     visibility = ["//visibility:public"],
     copts = [
-          "-DHAVE_STD_REGEX"
+        "-DHAVE_STD_REGEX",
     ],
 )

--- a/ci/bazel/BUILD.benchmark
+++ b/ci/bazel/BUILD.benchmark
@@ -1,0 +1,14 @@
+cc_library(
+    name = "benchmark",
+    srcs = glob(["src/*.cc"],
+                exclude = ["src/re_posix.cc", "src/gnuregex.cc"]),
+    hdrs = glob(["src/*.h", "include/benchmark/*.h"],
+                exclude = ["src/re_posix.h", "src/gnuregex.h"]),
+    includes = [
+         "include",
+    ],
+    visibility = ["//visibility:public"],
+    copts = [
+          "-DHAVE_STD_REGEX"
+    ],
+)

--- a/ci/build/build.sh
+++ b/ci/build/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -e
+if [ ! -z "${RECIPE_DEBUG}" ]; then
+  set -x
+fi
 
 PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../..;pwd)
 

--- a/ci/build/build.sh
+++ b/ci/build/build.sh
@@ -1,10 +1,60 @@
 #!/bin/bash
 
-bazel \
-  --output_base=$HOME/.cache/bazel \
-  build \
-  "//recipe/..."
-bazel \
-  --output_base=$HOME/.cache/bazel \
-  test \
-  "//recipe/..."
+set -e
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../..;pwd)
+
+run_build() {
+  bazel \
+    --output_base=$HOME/.cache/bazel \
+    build \
+    ${BAZEL_OPTION} \
+    "//recipe/..."
+}
+
+run_test() {
+  bazel \
+    --output_base=$HOME/.cache/bazel \
+    test \
+    ${BAZEL_OPTION} \
+    "//recipe/..."
+}
+
+run_benchmark() {
+  ${PATH_TO_REPOSITORY}/tools/run_benchmark.sh
+}
+
+is_covereage() {
+  [[ `echo "${BUILD_TARGET}" | grep -E '(Coverage$|Coverage,)'` ]]
+}
+
+is_benchmark() {
+  [[ `echo "${BUILD_TARGET}" | grep -E '(Benchmark$|Benchmark,)'` ]]
+}
+
+
+if [[ "${BUILD_TYPE}" == "Release" ]]; then
+  BAZEL_OPTION="${BAZEL_OPTION} --compilation_mode=opt"
+else
+  # by default, debug build
+  # but if we build benchmarks, we build it with optimization
+  if is_benchmark; then
+    echo "Warning! Force to compile with optimization because benchmarks are buiit"
+    BAZEL_OPTION="${BAZEL_OPTION} --compilation_mode=opt"
+  else
+    BAZEL_OPTION="${BAZEL_OPTION} --compilation_mode=dbg"
+  fi
+fi
+
+#
+# build and test
+#
+run_build
+run_test
+
+if is_covereage; then
+  # take coverage
+  echo "TODO: take coverage"
+elif is_benchmark; then
+  run_benchmark
+fi

--- a/ci/build/check_sanity.sh
+++ b/ci/build/check_sanity.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 do_buildifier(){
-  local BUILD_FILES=$(find . -name 'BUILD*')
+  local BUILD_FILES=$(find . -type f -name BUILD -or -name 'BUILD.*' -or -name BUILD.bazel)
   local NUM_BUILD_FILES=$(echo ${BUILD_FILES} | wc -w)
 
   echo "Running do_buildifier on ${NUM_BUILD_FILES} files"
@@ -63,7 +63,7 @@ get_clang_files_to_check() {
 
     echo "${CLANG_FILES}"
   else
-    find recipe -name '*.h' -o -name '*.cc'
+    find benchmark recipe -name '*.h' -o -name '*.cc'
   fi
 }
 

--- a/ci/travis/after_success.sh
+++ b/ci/travis/after_success.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-if [[ "${BUILD_TYPE}" == "Coverage" -a "${TRAVIS_OS_NAME}" == "linux" ]]; then
+set -e
+set -o pipefail
+set -o nounset
+
+if [[ `echo "${BUILD_TARGET}" | grep -E '(Coverage$|Coverage,)'` && "${TRAVIS_OS_NAME}" == "linux" ]]; then
+  # -g
   pwd;
   coveralls \
     --verbose \
     --include recipe \
-    --exclude submodule \
     --gcov-options '\-lp' \
     --root . \
-    --build-root build;
+    --build-root bazel-out/darwin-dbg/bin/recipe
 fi

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -19,7 +19,7 @@ ${PATH_TO_ROOT}/ci/travis/install_valgrind.sh
 # coverage report
 # we only measure coverage on Linux
 #
-if [[ "${BUILD_TYPE}" == "Coverage" && "${TRAVIS_OS_NAME}" == "linux" ]]; then
+if [[ `echo "${BUILD_TARGET}" | grep -E '(Coverage$|Coverage,)'` && "${TRAVIS_OS_NAME}" == "linux" ]]; then
   PATH=~/.local/bin:${PATH};
   pip install --user --upgrade pip;
   pip install --user cpp-coveralls;

--- a/recipe/integrate/sample.cc
+++ b/recipe/integrate/sample.cc
@@ -2,6 +2,6 @@
 
 namespace recipe {
 namespace integrate {
-int hoge() { return 1; }
+int Foobar(const int x) { return x; }
 }  // namespace integrate
 }  // namespace recipe

--- a/recipe/integrate/sample.h
+++ b/recipe/integrate/sample.h
@@ -2,6 +2,6 @@
 
 namespace recipe {
 namespace integrate {
-int hoge();
+int Foobar(const int x);
 }  // namespace integrate
 }  // namespace recipe

--- a/recipe/integrate/sample_test.cc
+++ b/recipe/integrate/sample_test.cc
@@ -3,8 +3,8 @@
 
 namespace recipe {
 namespace integrate {
-TEST(hoge_test, simple) {
-  const int actual = hoge();
+TEST(sample_Foobar_test, simple) {
+  const int actual = Foobar(1);
   EXPECT_EQ(1, actual);
 }
 }  // namespace integrate

--- a/recipe/sandbox/sample.cc
+++ b/recipe/sandbox/sample.cc
@@ -2,6 +2,6 @@
 
 namespace recipe {
 namespace sandbox {
-int hoge() { return 1; }
+int Foo() { return 1; }
 }  // namespace sandbox
 }  // namespace recipe

--- a/recipe/sandbox/sample.h
+++ b/recipe/sandbox/sample.h
@@ -2,6 +2,6 @@
 
 namespace recipe {
 namespace sandbox {
-int hoge();
+int Foo();
 }  // namespace sandbox
 }  // namespace recipe

--- a/recipe/sandbox/sample_test.cc
+++ b/recipe/sandbox/sample_test.cc
@@ -3,8 +3,8 @@
 
 namespace recipe {
 namespace sandbox {
-TEST(hoge_test, simple) {
-  const int actual = hoge();
+TEST(sample_foo_test, simple) {
+  const int actual = Foo();
   EXPECT_EQ(1, actual);
 }
 }  // namespace sandbox

--- a/recipe/util/sample.cc
+++ b/recipe/util/sample.cc
@@ -3,8 +3,8 @@
 
 namespace recipe {
 namespace util {
-int hoge() {
-  LOG(INFO) << "file";
+int Bar() {
+  DLOG(INFO) << "file";
   return 1;
 }
 }  // namespace util

--- a/recipe/util/sample.h
+++ b/recipe/util/sample.h
@@ -2,6 +2,6 @@
 
 namespace recipe {
 namespace util {
-int hoge();
+int Bar();
 }  // namespace util
 }  // namespace recipe

--- a/recipe/util/sample_test.cc
+++ b/recipe/util/sample_test.cc
@@ -3,8 +3,8 @@
 
 namespace recipe {
 namespace util {
-TEST(hoge_test, simple) {
-  const int actual = hoge();
+TEST(sample_bar_test, simple) {
+  const int actual = Bar();
   EXPECT_EQ(1, actual);
 }
 }  // namespace util

--- a/tools/buildifier.sh
+++ b/tools/buildifier.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ..;pwd)
+cd $PATH_TO_REPOSITORY
+
+buildifier \
+  -showlog \
+  -mode=fix \
+  $(find . -type f -name BUILD -or -name 'BUILD.*' -or -name BUILD.bazel)

--- a/tools/formatter.sh
+++ b/tools/formatter.sh
@@ -2,10 +2,23 @@
 
 set -e
 
+formatting() {
+  local directory_name="$1"
+  for filename in $(find ${directory_name} -name '*.h' -o -name '*.cc'); do
+    clang-format -i $filename
+    # clang-format --style=google $filename | diff $filename - > /dev/null
+  done
+}
+
 PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ..;pwd)
 cd $PATH_TO_REPOSITORY
 
-for filename in $(find recipe -name '*.h' -o -name '*.cc'); do
-  clang-format -i $filename
-  # clang-format --style=google $filename | diff $filename - > /dev/null
-done
+#
+# under recipe/
+#
+formatting recipe
+
+#
+# under benchmark/
+#
+formatting benchmark

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -e
+if [ ! -z "${RECIPE_DEBUG}" ]; then
+  set -x
+fi
 
 PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ..;pwd)
 cd $PATH_TO_REPOSITORY
@@ -8,9 +11,14 @@ cd $PATH_TO_REPOSITORY
 run_benchmark()
 {
   local subpackage="$1"
-  bazel run --compilation_mode=opt "//benchmark/recipe/${subpackage}"
+  bazel \
+    --output_base=$HOME/.cache/bazel \
+    run \
+    --compilation_mode=opt \
+    "//benchmark/recipe/${subpackage}"
 }
 
+pwd
 run_benchmark integrate
 run_benchmark sandbox
 run_benchmark util

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ..;pwd)
+cd $PATH_TO_REPOSITORY
+
+run_benchmark()
+{
+  local subpackage="$1"
+  bazel run --compilation_mode=opt "//benchmark/recipe/${subpackage}"
+}
+
+run_benchmark integrate
+run_benchmark sandbox
+run_benchmark util


### PR DESCRIPTION
## Summary
This PR make it available to add benchmark tests. We use [google/benchmark](https://github.com/google/benchmark) for benchmarking. See the official documentation for the usage.

## Other changes

* Travis CI
    * We run benchmark tests with clang and gcc on Linux
    * Running tests on OSX takes more time compared with Linux because of shortage of OSX machine in Travis CI
* `check_sanity.sh`
    * buildifier checks format of files in `benchmark/`
    * clang-format checks format of files in `benchmark/`
* `formatter.sh`
    * supports formatting files in `benchmark/`
* `run_benchmark.sh`
    * supports to run all benchmark tests
    * The reason of using scripts is that bazel does not support to run multiple execution files (i.e. binaries generated by `cc_binary`)

