### PR TITLE
Add docker images to debug gcc compiler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+#
+# bazel
+#
+bazel-bazel-test
+bazel-bin
+bazel-genfiles
+bazel-out
+bazel-testlogs
+bazel-*
+
+#
+# ruby
+# Currently, this is only for travis CLI to manage ".travis.yml"
+#
+/Gemfile
+/Gemfile.lock
+/.bundle
+/vendor
+
+#
+# editor
+#
+.vscode
+
+#
+# repository specific
+#

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ cmake
 /lib*
 
 #
+# editor
+#
+.vscode
+
+#
 # bazel
 #
 /bazel-bazel-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,13 @@ buildifier -showlog -mode=fix $(find . -type f -name BUILD -or -name 'BUILD.*' -
 We use [google/glog](https://github.com/google/glog) for logging. See [documentation](http://rpg.ifi.uzh.ch/docs/glog.html).
 The log message will be logged to `/tmp/<program name>.<hostname>.<user name>.log.<severity level>.<date>.<time>.<pid>`. (e.g., "/tmp/hello_world.example.com.hamaji.log.INFO.20080709-222411.10474")
 
+## Debugging
+We support the `gcc` compiler and `clang` compiler now so that we run all tests with both compilers in CI environments.
+Running multiple compilers in the same machine is sometimes annoying developers because of their dependency.
+For debugging in another compiler, we provide docker images.
+See `tools/docker/gcc` for the GCC compiler.
+
+
 ## TODO
 
 * [x] lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,15 +28,15 @@ We use gtest for testing. Take a look at official documents:
 You can run all tests with command
 
 ```
-bazel test "//recipe/..."
+bazel test --test_output=errors "//recipe/..."
 ```
 
 Executing tests for specific subpackages is also possible
 
 ```
-bazel test //recipe/integrate:test
-bazel build //recipe/sandbox:sandbox
-bazel test //recipe/util:test
+bazel test --test_output=errors //recipe/integrate:test
+bazel test --test_output=errors //recipe/sandbox:sandbox
+bazel test --test_output=errors //recipe/util:test
 ```
 
 ## Benchmark

--- a/ci/_lib/common_option.sh
+++ b/ci/_lib/common_option.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+#
+# usage:
+#   contain_element "${array_var[@]}" <value_of_element>
+#
+contain_element () {
+  local e match="$1"
+  shift
+  for e; do
+    [[ "$e" == "$match" ]] && return 0
+  done
+  return 1
+}
+
+while [[ $# -gt 0 ]]
+do
+  case ${1} in
+    --debug|-d)
+      set -x
+    ;;
+
+    --do-update|-s)
+      # update package managers before installing
+      readonly _do_update=1
+    ;;
+
+    --use-sudo|-S)
+      # use sudo command to install packages
+      readonly _use_sudo=1
+    ;;
+
+    --distribution|-d)
+      readonly _distribution="$2"
+      # valid values are
+      valid_distributions=("ubuntu1404" "ubuntu1604")
+      if contain_element "${valid_values[@]}" "${_distribution}" ; then
+        echo "[ERROR] Invalid option '${1} ${2}'"
+        exit 1
+      fi
+      shift || true
+    ;;
+
+    *)
+      echo "[ERROR] Invalid option '${1}'"
+      exit 1
+    ;;
+  esac
+  shift || true  # in case of set -e
+done

--- a/ci/_lib/install_bazel.sh
+++ b/ci/_lib/install_bazel.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+#
+# install_bazel.sh
+#
+# variables:
+#   * _do_update=1
+#   * _use_sudo=1
+#   * _do_update=1
+#
+install_bazel_linux()
+{
+
+  if [[ ${_use_sudo} -eq 1 ]]; then
+    local SUDO="sudo"
+  fi
+
+  if [[ ${_do_update} -eq 1 ]]; then
+    ${SUDO} apt-get update
+  fi
+
+  ${SUDO} apt-get install -y \
+    software-properties-common \
+    curl
+
+  # install JDK
+  ${SUDO} add-apt-repository -y ppa:webupd8team/java
+  ${SUDO} apt-get update
+  # to automatically agree with license of openjdk
+  echo debconf shared/accepted-oracle-license-v1-1 select true | \
+    ${SUDO} debconf-set-selections
+  echo debconf shared/accepted-oracle-license-v1-1 seen true | \
+    ${SUDO} debconf-set-selections
+  ${SUDO} apt-get install -y openjdk-8-jdk
+
+  echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | ${SUDO} tee /etc/apt/sources.list.d/bazel.list
+  curl https://bazel.build/bazel-release.pub.gpg | ${SUDO} apt-key add -
+  ${SUDO} apt-get update
+  ${SUDO} apt-get install -y bazel
+}
+
+#
+# variables:
+#   * _do_update=1
+#
+install_bazel_osx()
+{
+  if [[ ${_do_update} -eq 1 ]]; then
+    brew update
+  fi
+
+  brew cask install homebrew/cask-versions/java8
+  brew install bazel
+}

--- a/ci/_lib/install_clang_format.sh
+++ b/ci/_lib/install_clang_format.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_LIB=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd )
+source ${PATH_TO_LIB}/util.sh
+
+#
+# _use_sudo=1
+# _do_update=1
+#
+install_clang_format_linux()
+{
+  if [[ ${_use_sudo} -eq 1 ]]; then
+    local SUDO="sudo"
+  fi
+
+  if [[ ${_do_update} -eq 1 ]]; then
+    ${SUDO} apt-get update
+  fi
+
+  UBUNTU_VERSION=`get_ubuntu_version`
+  if [[ "$UBUNTU_VERSION" == "14.04" ]]; then
+    ${SUDO} apt-get install -y clang-format-3.9
+  else
+    ${SUDO} apt-get install -y clang-format
+  fi
+}
+
+#
+#
+#
+install_clang_format_osx()
+{
+  if [[ ${_do_update} -eq 1 ]]; then
+    brew update
+  fi
+
+  brew install clang-format
+}

--- a/ci/_lib/install_gcc.sh
+++ b/ci/_lib/install_gcc.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_LIB=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd )
+source ${PATH_TO_LIB}/util.sh
+
+#
+# _use_sudo=1
+# _do_update=1
+# _distribution="ubuntu1404"
+#
+install_gcc49_linux()
+{
+  if [[ ${_use_sudo} -eq 1 ]]; then
+    local SUDO="sudo"
+  fi
+
+  if [[ ${_do_update} -eq 1 ]]; then
+    ${SUDO} apt-get update
+  fi
+
+  local UBUNTU_VERSION=`get_ubuntu_version`
+  if [[ ${UBUNTU_VERSION} == "14.04" ]]; then
+    ${SUDO} add-apt-repository ppa:ubuntu-toolchain-r/test < /dev/null
+    ${SUDO} apt-get update
+  fi
+
+  ${SUDO} apt-get install -y \
+    gcc-4.9 \
+    g++-4.9
+
+  export CXX="g++-4.9"
+  export CC="gcc-4.9"
+}
+
+#
+# _do_update=1
+#
+install_gcc49_osx()
+{
+  if [[ ${_do_update} -eq 1 ]]; then
+    brew update
+  fi
+
+  gcc --version
+  g++ --version
+  brew install gcc@5 || brew link --overwrite gcc@5
+  gcc --version
+  g++ --version
+}

--- a/ci/_lib/util.sh
+++ b/ci/_lib/util.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#
+# return:
+#   * 14.04
+#   * 16.06
+#   * etc.
+#
+get_ubuntu_version()
+{
+  cat /etc/lsb-release | grep "DISTRIB_RELEASE" | awk -F '=' '{ print $2 }'
+}
+

--- a/ci/linux/install_bazel.sh
+++ b/ci/linux/install_bazel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/common_option.sh
+
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_bazel_linux

--- a/ci/linux/install_clang_format.sh
+++ b/ci/linux/install_clang_format.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/common_option.sh
+
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_clang_format_osx

--- a/ci/linux/install_gcc.sh
+++ b/ci/linux/install_gcc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/common_option.sh
+
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_gcc49_linux

--- a/ci/linux/install_valgrind.sh
+++ b/ci/linux/install_valgrind.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/common_option.sh
+
+if [[ ${_use_sudo} -eq 1 ]]; then
+  SUDO="sudo"
+fi
+
+if [[ ${_do_update} -eq 1 ]]; then
+  ${SUDO} apt-get update
+fi
+
+${SUDO} apt-get install -y curl
+export BASEPATH=`pwd`;
+mkdir -p ${BASEPATH}/usr ;
+export PATH="${BASEPATH}/usr/bin:$PATH" ;
+export LD_LIBRARY_PATH="${BASEPATH}/usr/lib:$LD_LIBRARY_PATH";
+curl -L -O http://valgrind.org/downloads/valgrind-3.12.0.tar.bz2 ;
+tar xjf valgrind-3.12.0.tar.bz2 ;
+cd valgrind-3.12.0 ;
+./configure --prefix=${BASEPATH}/usr > /dev/null ;
+make -j3 > /dev/null ;
+make install > /dev/null ;
+cd .. ;
+valgrind --version;

--- a/ci/osx/install_bazel.sh
+++ b/ci/osx/install_bazel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/common_option.sh
+
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_bazel_osx

--- a/ci/osx/install_clang_format.sh
+++ b/ci/osx/install_clang_format.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/common_option.sh
+
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_clang_format_osx

--- a/ci/osx/install_gcc.sh
+++ b/ci/osx/install_gcc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/common_option.sh
+
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_gcc49_osx

--- a/ci/travis/after_success.sh
+++ b/ci/travis/after_success.sh
@@ -3,6 +3,9 @@
 set -e
 set -o pipefail
 set -o nounset
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
 
 if [[ `echo "${BUILD_TARGET}" | grep -E '(Coverage$|Coverage,)'` && "${TRAVIS_OS_NAME}" == "linux" ]]; then
   # -g

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
 PATH_TO_SCRIPT=$( cd ${0%/*} && pwd -P )
 PATH_TO_ROOT=$( cd "$PATH_TO_SCRIPT/../.." && pwd -P )
 
@@ -9,11 +13,12 @@ ls -la
 
 #
 # install
+# sourcing is required to export some variables
 #
-${PATH_TO_ROOT}/ci/travis/install_bazel.sh
-${PATH_TO_ROOT}/ci/travis/install_clang_format.sh
-${PATH_TO_ROOT}/ci/travis/install_gcc.sh
-${PATH_TO_ROOT}/ci/travis/install_valgrind.sh
+source ${PATH_TO_ROOT}/ci/travis/install_bazel.sh
+source ${PATH_TO_ROOT}/ci/travis/install_clang_format.sh
+source ${PATH_TO_ROOT}/ci/travis/install_gcc.sh
+# ${PATH_TO_ROOT}/ci/travis/install_valgrind.sh
 
 #
 # coverage report

--- a/ci/travis/install_bazel.sh
+++ b/ci/travis/install_bazel.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 
 set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
 
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  brew cask install homebrew/cask-versions/java8
-  brew install bazel
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/install_bazel.sh
+
+if [[ "$TRAVIS_OS_NAME" == "" ]]; then
+  echo "\$TRAVIS_OS_NAME is not set."
+  exit 1
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  sudo apt-get install -y --force-yes openjdk-8-jdk
-  sudo add-apt-repository -y ppa:webupd8team/java
-  sudo apt-get update
-  sudo apt-get install -y oracle-java8-installer
-  echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-  curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-  sudo apt-get update
-  sudo apt-get install -y bazel
+  _use_sudo=1 install_bazel_linux
+fi
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  install_bazel_osx
 fi

--- a/ci/travis/install_clang_format.sh
+++ b/ci/travis/install_clang_format.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
 set -e
-
-#
-# install clang-format
-#
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  brew install clang-format
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
 fi
 
-#
-# install clang-format
-#
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/install_clang_format.sh
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+if [[ "$TRAVIS_OS_NAME" == "" ]]; then
+  echo '$TRAVIS_OS_NAME is not set.'
+  exit 1
+fi
+
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  sudo apt-get install -y clang-format
+  _use_sudo=1 install_clang_format_linux
+fi
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  install_clang_format_osx
 fi

--- a/ci/travis/install_gcc.sh
+++ b/ci/travis/install_gcc.sh
@@ -1,25 +1,39 @@
 #!/bin/bash
 
+#
+# The script export CXX and CC, so you need to source the script
+#
+# Usage:
+# source install_gcc.sh
+#
+
 set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/install_gcc.sh
+
+if [[ "$TRAVIS_OS_NAME" == "" ]]; then
+  echo '$TRAVIS_OS_NAME is not set.'
+  exit 1
+fi
 
 #
 # install gcc
 # gcc does not exist on OSX by default
 #
-if [ "$TRAVIS_OS_NAME" == "osx" -a "$CXX" == "g++" ]; then
-  gcc --version;
-  g++ --version;
-  brew update;
-  brew install gcc@5 || brew link --overwrite gcc@5;
-  gcc --version;
-  g++ --version;
+if [[ "$TRAVIS_OS_NAME" == "osx" && "$CXX" == "g++" ]]; then
+  install_gcc49_osx
   export CXX="g++";
 fi
 
 #
 # install g++4.9
 #
-if [[ "$TRAVIS_OS_NAME" == "linux" -a "$CXX" == "g++" ]]; then
-  sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9
-  export CXX="g++-4.9" CC="gcc-4.9";
+if [[ "$TRAVIS_OS_NAME" == "linux" && "$CXX" == "g++" ]]; then
+  _use_sudo=1 _distribution="ubuntu1404" install_gcc49_linux
+  export CXX="g++-4.9"
+  export CC="gcc-4.9"
 fi

--- a/ci/travis/install_valgrind.sh
+++ b/ci/travis/install_valgrind.sh
@@ -1,23 +1,21 @@
 #!/bin/bash
 
 set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+
+if [[ "$TRAVIS_OS_NAME" == "" ]]; then
+  echo '$TRAVIS_OS_NAME is not set.'
+  exit 1
+fi
 
 #
 # Install valgrind
 # valgrind does not work in osx, so we only run tests with valgrind on linux
 #
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  sudo apt-get install -y curl
-  export BASEPATH=`pwd`;
-  mkdir -p ${BASEPATH}/usr ;
-  export PATH="${BASEPATH}/usr/bin:$PATH" ;
-  export LD_LIBRARY_PATH="${BASEPATH}/usr/lib:$LD_LIBRARY_PATH";
-  curl -L -O http://valgrind.org/downloads/valgrind-3.12.0.tar.bz2 ;
-  tar xjf valgrind-3.12.0.tar.bz2 ;
-  cd valgrind-3.12.0 ;
-  ./configure --prefix=${BASEPATH}/usr > /dev/null ;
-  make -j3 > /dev/null ;
-  make install > /dev/null ;
-  cd .. ;
-  valgrind --version;
+  ${PATH_TO_CI}/${TRAVIS_OS_NAME}/install_valgrind.sh --use-sudo
 fi

--- a/tools/docker/gcc/Dockerfile
+++ b/tools/docker/gcc/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+#
+# run on the top of repository
+#
+COPY ci /tmp/ci
+
+RUN \
+    apt-get update \
+    && /tmp/ci/linux/install_bazel.sh \
+    && /tmp/ci/linux/install_clang_format.sh \
+    && /tmp/ci/linux/install_gcc.sh \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/ci
+
+ENV \
+  CXX="g++-4.9" \
+  CC="gcc-4.9"

--- a/tools/docker/gcc/README.md
+++ b/tools/docker/gcc/README.md
@@ -1,0 +1,17 @@
+## Dockerfiles for debugging gcc-4.9/g++-4.9
+Build docker images.
+
+```
+docker build -t recipe/gcc:4.9 .
+```
+
+Run docker container
+
+```
+docker run \
+    --rm \
+    -it \
+    --volume ${PATH_TO_REPOSITORY}:/tmp/repository \
+    --workdir /tmp/repository \
+    /bin/bash
+```

--- a/tools/docker/gcc/README.md
+++ b/tools/docker/gcc/README.md
@@ -1,17 +1,12 @@
 ## Dockerfiles for debugging gcc-4.9/g++-4.9
-Build docker images.
+Build docker images with the command
 
 ```
-docker build -t recipe/gcc:4.9 .
+./docker_build.sh
 ```
 
-Run docker container
+Run docker container and attach to it
 
 ```
-docker run \
-    --rm \
-    -it \
-    --volume ${PATH_TO_REPOSITORY}:/tmp/repository \
-    --workdir /tmp/repository \
-    /bin/bash
+./docker_run.sh
 ```

--- a/tools/docker/gcc/docker_build.sh
+++ b/tools/docker/gcc/docker_build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../../../;pwd)
+docker build \
+  -t recipe/gcc:4.9 \
+  -f ${PATH_TO_REPOSITORY}/tools/docker/gcc/Dockerfile \
+  ${PATH_TO_REPOSITORY}

--- a/tools/docker/gcc/docker_build_ubuntu1404.sh
+++ b/tools/docker/gcc/docker_build_ubuntu1404.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../../../;pwd)
+docker build \
+  -t recipe/gcc:4.9 \
+  -f ${PATH_TO_REPOSITORY}/tools/docker/gcc/ubuntu1404/Dockerfile \
+  ${PATH_TO_REPOSITORY}

--- a/tools/docker/gcc/docker_build_ubuntu1604.sh
+++ b/tools/docker/gcc/docker_build_ubuntu1604.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../../../;pwd)
+docker build \
+  -t recipe/gcc:4.9 \
+  -f ${PATH_TO_REPOSITORY}/tools/docker/gcc/ubuntu1604/Dockerfile \
+  ${PATH_TO_REPOSITORY}

--- a/tools/docker/gcc/docker_run.sh
+++ b/tools/docker/gcc/docker_run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../../..;pwd)
+
+docker run \
+    --rm \
+    -it \
+    --volume ${PATH_TO_REPOSITORY}:/tmp/repository \
+    --workdir /tmp/repository \
+    recipe/gcc:4.9 \
+    /bin/bash

--- a/tools/docker/gcc/docker_run_ubuntu1604.sh
+++ b/tools/docker/gcc/docker_run_ubuntu1604.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../../..;pwd)
+
+docker run \
+    --rm \
+    -it \
+    --volume ${PATH_TO_REPOSITORY}:/tmp/repository \
+    --workdir /tmp/repository \
+    recipe/gcc:4.9 \
+    /bin/bash

--- a/tools/docker/gcc/ubuntu1404/Dockerfile
+++ b/tools/docker/gcc/ubuntu1404/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:14.04
+
+#
+# run on the top of repository
+#
+COPY ci /tmp/ci
+
+RUN \
+    apt-get update \
+    && /tmp/ci/linux/install_bazel.sh \
+    && /tmp/ci/linux/install_clang_format.sh \
+    && /tmp/ci/linux/install_gcc.sh \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/ci
+
+ENV \
+  CXX="g++-4.9" \
+  CC="gcc-4.9"

--- a/tools/docker/gcc/ubuntu1604/Dockerfile
+++ b/tools/docker/gcc/ubuntu1604/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:16.04
+
+#
+# run on the top of repository
+#
+COPY ci /tmp/ci
+
+RUN \
+    apt-get update \
+    && /tmp/ci/linux/install_bazel.sh \
+    && /tmp/ci/linux/install_clang_format.sh \
+    && /tmp/ci/linux/install_gcc.sh \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/ci
+
+ENV \
+  CXX="g++-4.9" \
+  CC="gcc-4.9"
+


### PR DESCRIPTION
## Summary
The PR adds some Docker images and shell scripts for 
The directory structure and existing scripts are completely organized for the DRY principle.

## Environment variables
* `RECIPE_DEBUG`
    * if you want to debug shell scripts executed in Travis CI or Docker daemon, defining the environment variable `RECIPE_DEBUG` enables `set -x` option in the scripts

## Directory structure
* `tools/docker/gcc/ubuntu1404/`
    * We use ubuntu 14.04 to build the library on Travis CI, so this docker image can be used to reproduce results on the environment of Travis CI
* `tools/docker/gcc/ubuntu1604/`
    * We recommend using ubuntu 16.04 as base docker image. 14.04 is only supported to maintain Travis CI.

* `ci/_lib/`
    * common scripts for continuous integration
    * The underbar is added to avoid the confliction to the conventional name of Linux system
* `ci/linux/`
    * scripts for CI environment on linux
* `ci/osx/`
    * scripts for CI environment on OSX
* `ci/travis/`
    * scripts for CI environment on Travis
    * scripts in this directory can depend on Travis CI environment variables
