### PR TITLE
Add linear equation solver for band-diagonal matrix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,12 @@
 #
+# from bazel 0.20.0, the following rules are deprecated,
+# so explicit load is required
+#
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+#
 # glog
 #
 git_repository(
@@ -18,18 +26,20 @@ new_git_repository(
 #
 # gtest
 # bazel build @gtest//:gtest
+# Since 1.8.1, gtest contains BUILD.bazel in the archive
 #
-new_http_archive(
+http_archive(
     name = "gtest",
-    url = "https://github.com/google/googletest/archive/release-1.8.0.zip",
-    build_file = "//ci/bazel:BUILD.gtest",
+    url = "https://github.com/abseil/googletest/archive/release-1.8.0.zip",
     strip_prefix = "googletest-release-1.8.0/googletest",
+    build_file = "//ci/bazel:BUILD.gtest",
 )
 
 #
 # google/benchmark
+# bazel build @benchmark//:benchmark
 #
-new_http_archive(
+http_archive(
     name = "benchmark",
     build_file = "//ci/bazel:BUILD.benchmark",
     sha256 = "f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d",

--- a/ci/_lib/install_bazel.sh
+++ b/ci/_lib/install_bazel.sh
@@ -24,8 +24,10 @@ install_bazel_linux()
     ${SUDO} apt-get update
   fi
 
+  # bazel's git_repository rule requires git
   ${SUDO} apt-get install -y \
     software-properties-common \
+    git \
     curl
 
   # install JDK

--- a/ci/linux/install_bazel.sh
+++ b/ci/linux/install_bazel.sh
@@ -6,6 +6,6 @@ if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
 fi
 
 PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
-source ${PATH_TO_CI}/_lib/common_option.sh
+source ${PATH_TO_CI}/_lib/install_bazel.sh
 
 _use_sudo=${_use_sudo} _do_update=${_do_update} install_bazel_linux

--- a/ci/linux/install_clang_format.sh
+++ b/ci/linux/install_clang_format.sh
@@ -6,6 +6,6 @@ if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
 fi
 
 PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
-source ${PATH_TO_CI}/_lib/common_option.sh
+source ${PATH_TO_CI}/_lib/install_clang_format.sh
 
-_use_sudo=${_use_sudo} _do_update=${_do_update} install_clang_format_osx
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_clang_format_linux

--- a/ci/linux/install_gcc.sh
+++ b/ci/linux/install_gcc.sh
@@ -6,6 +6,6 @@ if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
 fi
 
 PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
-source ${PATH_TO_CI}/_lib/common_option.sh
+source ${PATH_TO_CI}/_lib/install_gcc.sh
 
 _use_sudo=${_use_sudo} _do_update=${_do_update} install_gcc49_linux

--- a/recipe/integrate/main_test.cc
+++ b/recipe/integrate/main_test.cc
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/recipe/linear_algebra/band_diagonal.cc
+++ b/recipe/linear_algebra/band_diagonal.cc
@@ -1,0 +1,71 @@
+#include "recipe/linear_algebra/band_diagonal.h"
+#include <memory>
+#include "recipe/linear_algebra/lu_decomposition.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+//
+// GaussianEliminationOuterProductBandDiagonal
+//
+
+void GaussianEliminationOuterProductBandDiagonal(double* mat,
+                                                 const int mat_size,
+                                                 const int upper_band,
+                                                 const int lower_band) {
+  // matrix should be band diagonal matrix
+  for (int k = 0; k < mat_size - 1; ++k) {
+    // elimiate k-th row
+    for (int row = k + 1; row < std::min(k + lower_band + 1, mat_size); ++row) {
+      MATRIX(mat, mat_size, row, k) /= MATRIX(mat, mat_size, k, k);
+    }
+
+    for (int row = k + 1; row < std::min(k + lower_band + 1, mat_size); ++row) {
+      for (int col = k + 1; col < std::min(k + upper_band + 1, mat_size);
+           ++col) {
+        MATRIX(mat, mat_size, row, col) -=
+            MATRIX(mat, mat_size, row, k) * MATRIX(mat, mat_size, k, col);
+      }
+    }
+  }
+}
+
+void GaussianEliminationOuterProductBandDiagonal(double* mat,
+                                                 const int mat_size,
+                                                 const int band_size) {
+  GaussianEliminationOuterProductBandDiagonal(mat, mat_size, band_size,
+                                              band_size);
+}
+
+//
+// Solve Linear Equations
+//
+
+// void SolveLinearEquationWithLU(const double* mat_lu, const int mat_size,
+//                                double* vec_b) {
+//   // Solve Ly=b with respect to y
+//   for (int row = 0; row < mat_size; ++row) {
+//     double sum = 0.0;
+//     for (int col = 0; col < row; ++col) {
+//       sum += MATRIX(mat_lu, mat_size, row, col) * vec_b[col];
+//     }
+//     vec_b[row] = (vec_b[row] - sum);
+//   }
+//
+//   // Solve Ux=y w.r.t. x
+//   SolveLinearEquationUpperTriangular(mat_lu, mat_size, mat_size, vec_b,
+//                                      mat_size);
+// }
+
+void SolveLinearEquationBandDiagonal(double* mat, const int mat_size,
+                                     const int upper_band, const int lower_band,
+                                     double* vec_b) {
+  // the size of vector must be matrix_size
+  GaussianEliminationOuterProductBandDiagonal(mat, mat_size, upper_band,
+                                              lower_band);
+  // LU
+  SolveLinearEquationWithLU(mat, mat_size, vec_b);
+}
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/band_diagonal.h
+++ b/recipe/linear_algebra/band_diagonal.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include "recipe/linear_algebra/base.h"
+#include "recipe/linear_algebra/operation.h"
+#include "recipe/linear_algebra/operator_unary.h"
+#include "recipe/linear_algebra/util.h"
+
+namespace recipe {
+namespace linear_algebra {
+/// @brief
+///
+/// $$
+///   \left(
+///       \begin{array}{ccccc}
+///           u_{1}^{1}   &           & \cdots & u_{n}^{1}   & u_{n}^{1}
+///           \\
+///           l_{1}^{2}   & u_{2}^{2} &        & \cdots      & \vdots
+///           \\
+///           \vdots      &           &        & \ddots      &
+///           \\
+///           l_{1}^{n-1} & \vdots    & \ddots & \ddots      & u_{n}^{n-1}
+///           \\
+///           l_{1}^{n}   & \cdots    &        & l_{n-1}^{n} & u_{n}^{n}
+///       \end{array}
+///   \right)
+/// $$
+///
+/// @param mat squared matrix. The result of LU decomposition stored in `mat`.
+/// @param mat_size the number of rows and cols.
+/// @param upper_band
+/// @param lower_band
+///
+void GaussianEliminationOuterProductBandDiagonal(double* mat,
+                                                 const int mat_size,
+                                                 const int upper_band,
+                                                 const int lower_band);
+
+/// @brief LU decomposition for a band diagonal matrix
+/// whose upper band and lower band has the same size
+void GaussianEliminationOuterProductBandDiagonal(double* mat,
+                                                 const int mat_size,
+                                                 const int band_size);
+
+/// Solve $Ax=b$ where $A$ is a squared matrix whose length of rows is
+/// `mat_size`
+void SolveLinearEquationBandDiagonal(double* mat, const int mat_size,
+                                     const int upper_band, const int lower_band,
+                                     double* vec_b);
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/band_diagonal_test.cc
+++ b/recipe/linear_algebra/band_diagonal_test.cc
@@ -1,0 +1,61 @@
+#include "recipe/linear_algebra/band_diagonal.h"
+#include <gtest/gtest.h>
+#include <cmath>
+#include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include "recipe/linear_algebra/test_util/test_data.h"
+#include "recipe/linear_algebra/util.h"
+#include "recipe/linear_algebra/vector.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+TEST(GaussianEliminationOuterProductBandDiagonalTest, Example) {
+  std::unique_ptr<double[]> mat = MakeDoubleArray({
+      // clang-format off
+    1, 2, 0,
+    4, 5, 6,
+    0, 8, 9,
+      // clang-format on
+  });
+  const int row_size = 3;
+  const int col_size = 3;
+  const int size = row_size * col_size;
+  const int upper_band = 1;
+  const int lower_band = 1;
+  GaussianEliminationOuterProductBandDiagonal(mat.get(), row_size, upper_band,
+                                              lower_band);
+
+  std::unique_ptr<double[]> expect = MakeDoubleArray({
+      // clang-format off
+    1.0, 2.0, 0.0,
+    4.0, -3.0, 6.0,
+    0.0, -8.0/3.0, 25.0,
+      // clang-format on
+  });
+  EXPECT_ARRAY_ELEMENT_EQ(expect, mat, size);
+}
+
+TEST(SolveLinearEquationBandDiagonalTest, Example) {
+  std::unique_ptr<double[]> mat = MakeDoubleArray({
+      // clang-format off
+    1.0, 2.0, 0.0,
+    4.0, 5.0, 6.0,
+    0.0, 8.0, 9.0,
+      // clang-format on
+  });
+  const int row_size = 3;
+  const int upper_band = 1;
+  const int lower_band = 1;
+  const int vec_size = 3;
+  std::unique_ptr<double[]> vec = MakeDoubleArray({10.0, 11.0, 12.0});
+  SolveLinearEquationBandDiagonal(mat.get(), row_size, upper_band, lower_band,
+                                  vec.get());
+
+  // Solution of Ax=b
+  std::unique_ptr<double[]> expect =
+      MakeDoubleArray({28.0 / 25.0, 111.0 / 25.0, -196.0 / 75.0});
+  EXPECT_ARRAY_ELEMENT_EQ(expect, vec, vec_size);
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/lu_decomposition.cc
+++ b/recipe/linear_algebra/lu_decomposition.cc
@@ -1,0 +1,32 @@
+#include "recipe/linear_algebra/lu_decomposition.h"
+#include <cassert>
+#include <cmath>
+#include <numeric>
+#include <stdexcept>
+#include "recipe/linear_algebra/triangular.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+//
+// Solve Linear Equations
+//
+
+void SolveLinearEquationWithLU(const double* mat_lu, const int mat_size,
+                               double* vec_b) {
+  // Solve Ly=b with respect to y
+  for (int row = 0; row < mat_size; ++row) {
+    double sum = 0.0;
+    for (int col = 0; col < row; ++col) {
+      sum += MATRIX(mat_lu, mat_size, row, col) * vec_b[col];
+    }
+    vec_b[row] = (vec_b[row] - sum);
+  }
+
+  // Solve Ux=y w.r.t. x
+  SolveLinearEquationUpperTriangular(mat_lu, mat_size, mat_size, vec_b,
+                                     mat_size);
+}
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/lu_decomposition.h
+++ b/recipe/linear_algebra/lu_decomposition.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <vector>
+#include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/operation.h"
+#include "recipe/linear_algebra/vector.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+/// @brief Solve $LUx=b$ with respect to $x$. The solution will be overwritten
+///
+/// @param mat_lu $LU$ matrix obtained
+///   as a result of `GaussianEliminationOuterProductBandDiagonal`
+///   or other LU decomposition algorithms.
+///   `mat_lu` must be squared matrix.
+/// @param mat_size row or col length of `mat_lu`.
+/// @param vec_b the size of $b$.
+///
+void SolveLinearEquationWithLU(const double* mat_lu, const int mat_size,
+                               double* vec_b);
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/lu_decomposition.h
+++ b/recipe/linear_algebra/lu_decomposition.h
@@ -13,8 +13,8 @@ namespace linear_algebra {
 ///   as a result of `GaussianEliminationOuterProductBandDiagonal`
 ///   or other LU decomposition algorithms.
 ///   `mat_lu` must be squared matrix.
-/// @param mat_size row or col length of `mat_lu`.
-/// @param vec_b the size of $b$.
+/// @param mat_size row or column length of `mat_lu`.
+/// @param vec_b $b$.
 ///
 void SolveLinearEquationWithLU(const double* mat_lu, const int mat_size,
                                double* vec_b);

--- a/recipe/linear_algebra/lu_decomposition_test.cc
+++ b/recipe/linear_algebra/lu_decomposition_test.cc
@@ -1,0 +1,42 @@
+#include "recipe/linear_algebra/lu_decomposition.h"
+#include <gtest/gtest.h>
+#include <cmath>
+#include <stdexcept>
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include "recipe/linear_algebra/util.h"
+#include "recipe/linear_algebra/vector.h"
+
+namespace recipe {
+namespace linear_algebra {
+TEST(SolveLinearEquationWithLUTest, Example) {
+  // A = {
+  // 1, 2, 3,
+  // 4, 5, 6,
+  // 7, 8, 0
+  // }
+  // mat_lu is LU decomposition of A
+  std::unique_ptr<double[]> mat_lu = MakeDoubleArray({
+      // clang-format off
+      1.0, 2.0, 3.0,
+      4.0, -3.0, -6.0,
+      7.0, 2.0, -9.0,
+      // clang-format on
+  });
+  const int mat_size = 3;
+  std::unique_ptr<double[]> vec_b = MakeDoubleArray({
+      // clang-format off
+        10.0, 11.0, 12.0,
+      // clang-format on
+  });
+  SolveLinearEquationWithLU(mat_lu.get(), mat_size, vec_b.get());
+
+  std::unique_ptr<double[]> expect = MakeDoubleArray({
+      // clang-format off
+        -28.0/3.0, 29.0/3.0, 0.0,
+      // clang-format on
+  });
+
+  EXPECT_ARRAY_ELEMENT_EQ(expect, vec_b, mat_size);
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/main_test.cc
+++ b/recipe/linear_algebra/main_test.cc
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/recipe/linear_algebra/matrix.h
+++ b/recipe/linear_algebra/matrix.h
@@ -35,6 +35,7 @@ class Matrix {
   Matrix& operator=(const Matrix& other);
   bool operator==(const Matrix& other) const;
   double* Get() { return data_.get(); };
+  const double* Get() const { return data_.get(); };
   inline int NumRow() const { return num_row_; }
   inline int NumCol() const { return num_col_; }
 };

--- a/recipe/linear_algebra/operation.cc
+++ b/recipe/linear_algebra/operation.cc
@@ -1,0 +1,68 @@
+#include "recipe/linear_algebra/operation.h"
+#include <memory>
+#include "recipe/linear_algebra/base.h"
+
+namespace recipe {
+namespace linear_algebra {
+// Calculate Ax + y
+std::unique_ptr<double[]> MatrixTimesVectorPlusVector(const double* mat_a,
+                                                      const int row_size,
+                                                      const int col_size,
+                                                      const double* vec_x,
+                                                      const double* vec_y) {
+  std::unique_ptr<double[]> data(new double[row_size]);
+  // x has colsize
+  // y has row_size
+  for (int row = 0; row < row_size; ++row) {
+    data[row] = vec_y[row];
+    for (int col = 0; col < col_size; ++col) {
+      data[row] += MATRIX(mat_a, col_size, row, col) * vec_x[col];
+    }
+  }
+  return data;
+}
+
+// Calculate Ax - y
+std::unique_ptr<double[]> MatrixTimesVectorMinusVector(const double* mat_a,
+                                                       const int row_size,
+                                                       const int col_size,
+                                                       const double* vec_x,
+                                                       const double* vec_y) {
+  std::unique_ptr<double[]> data(new double[row_size]);
+  // x has colsize
+  // y has row_size
+  for (int row = 0; row < row_size; ++row) {
+    data[row] = -vec_y[row];
+    for (int col = 0; col < col_size; ++col) {
+      data[row] += MATRIX(mat_a, col_size, row, col) * vec_x[col];
+    }
+  }
+  return data;
+}
+
+// Calculate -Ax + y
+std::unique_ptr<double[]> MinusMatrixTimesVectorPlusVector(
+    const double* mat_a, const int row_size, const int col_size,
+    const double* vec_x, const double* vec_y) {
+  std::unique_ptr<double[]> data(new double[row_size]);
+  // x has colsize
+  // y has row_size
+  for (int row = 0; row < row_size; ++row) {
+    data[row] = vec_y[row];
+    for (int col = 0; col < col_size; ++col) {
+      data[row] -= MATRIX(mat_a, col_size, row, col) * vec_x[col];
+    }
+  }
+  return data;
+}
+
+Vector MinusMatrixTimesVectorPlusVector(Matrix* mat_a, Vector* vec_x,
+                                        Vector* vec_y) {
+  const int row_size = mat_a->NumRow();
+  const int col_size = mat_a->NumCol();
+  std::unique_ptr<double[]> data = MinusMatrixTimesVectorPlusVector(
+      mat_a->Get(), row_size, col_size, vec_x->Get(), vec_y->Get());
+  return Vector(row_size, std::move(data));
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/operation.cc
+++ b/recipe/linear_algebra/operation.cc
@@ -11,8 +11,8 @@ std::unique_ptr<double[]> MatrixTimesVectorPlusVector(const double* mat_a,
                                                       const double* vec_x,
                                                       const double* vec_y) {
   std::unique_ptr<double[]> data(new double[row_size]);
-  // x has colsize
-  // y has row_size
+  // The size of x is col_size
+  // The size of y is row_size
   for (int row = 0; row < row_size; ++row) {
     data[row] = vec_y[row];
     for (int col = 0; col < col_size; ++col) {
@@ -29,8 +29,8 @@ std::unique_ptr<double[]> MatrixTimesVectorMinusVector(const double* mat_a,
                                                        const double* vec_x,
                                                        const double* vec_y) {
   std::unique_ptr<double[]> data(new double[row_size]);
-  // x has colsize
-  // y has row_size
+  // The size of x is col_size
+  // The size of y is row_size
   for (int row = 0; row < row_size; ++row) {
     data[row] = -vec_y[row];
     for (int col = 0; col < col_size; ++col) {
@@ -45,8 +45,8 @@ std::unique_ptr<double[]> MinusMatrixTimesVectorPlusVector(
     const double* mat_a, const int row_size, const int col_size,
     const double* vec_x, const double* vec_y) {
   std::unique_ptr<double[]> data(new double[row_size]);
-  // x has colsize
-  // y has row_size
+  // The size of x is col_size
+  // The size of y is row_size
   for (int row = 0; row < row_size; ++row) {
     data[row] = vec_y[row];
     for (int col = 0; col < col_size; ++col) {

--- a/recipe/linear_algebra/operation.h
+++ b/recipe/linear_algebra/operation.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <memory>
+#include "recipe/linear_algebra/base.h"
+#include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/vector.h"
+
+namespace recipe {
+namespace linear_algebra {
+// Calculate Ax + y
+std::unique_ptr<double[]> MatrixTimesVectorPlusVector(const double* mat_a,
+                                                      const int row_size,
+                                                      const int col_size,
+                                                      const double* vec_x,
+                                                      const double* vec_y);
+
+// Calculate Ax - y
+std::unique_ptr<double[]> MatrixTimesVectorMinusVector(const double* mat_a,
+                                                       const int row_size,
+                                                       const int col_size,
+                                                       const double* vec_x,
+                                                       const double* vec_y);
+
+// Calculate -Ax + y
+std::unique_ptr<double[]> MinusMatrixTimesVectorPlusVector(const double* mat_a,
+                                                           const int row_size,
+                                                           const int col_size,
+                                                           const double* vec_x,
+                                                           const double* vec_y);
+
+Vector MinusMatrixTimesVectorPlusVector(Matrix* mat_a, Vector* vec_x,
+                                        Vector* vec_y);
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/operation_test.cc
+++ b/recipe/linear_algebra/operation_test.cc
@@ -1,0 +1,66 @@
+#include "recipe/linear_algebra/operation.h"
+#include <gtest/gtest.h>
+#include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/test_util/test_data.h"
+#include "recipe/linear_algebra/util.h"
+
+namespace recipe {
+namespace linear_algebra {
+TEST(MatrixTimesVectorPlusVectorTest, Example) {
+  const int col_size = 2;
+  const int row_size = 2;
+  const int size = row_size * col_size;
+  std::unique_ptr<double[]> mat = TestData::GetRandomDoublePointer(size);
+
+  std::unique_ptr<double[]> vec_x = TestData::GetRandomDoublePointer(col_size);
+  std::unique_ptr<double[]> vec_y = TestData::GetRandomDoublePointer(row_size);
+
+  std::unique_ptr<double[]> actual = MatrixTimesVectorPlusVector(
+      mat.get(), row_size, col_size, vec_x.get(), vec_y.get());
+
+  // manually calculate
+  const double expect0 = mat[0] * vec_x[0] + mat[1] * vec_x[1] + vec_y[0];
+  const double expect1 = mat[2] * vec_x[0] + mat[3] * vec_x[1] + vec_y[1];
+  EXPECT_EQ(expect0, actual[0]);
+  EXPECT_EQ(expect1, actual[1]);
+}
+
+TEST(MatrixTimesVectorMinusVectorTest, Example) {
+  const int col_size = 2;
+  const int row_size = 2;
+  const int size = row_size * col_size;
+  std::unique_ptr<double[]> mat = TestData::GetRandomDoublePointer(size);
+
+  std::unique_ptr<double[]> vec_x = TestData::GetRandomDoublePointer(col_size);
+  std::unique_ptr<double[]> vec_y = TestData::GetRandomDoublePointer(row_size);
+
+  std::unique_ptr<double[]> actual = MatrixTimesVectorMinusVector(
+      mat.get(), row_size, col_size, vec_x.get(), vec_y.get());
+
+  // manually calculate
+  const double expect0 = mat[0] * vec_x[0] + mat[1] * vec_x[1] - vec_y[0];
+  const double expect1 = mat[2] * vec_x[0] + mat[3] * vec_x[1] - vec_y[1];
+  EXPECT_EQ(expect0, actual[0]);
+  EXPECT_EQ(expect1, actual[1]);
+}
+
+TEST(MinusMatrixTimesVectorPlusVectorTest, Example) {
+  const int col_size = 2;
+  const int row_size = 2;
+  const int size = row_size * col_size;
+  std::unique_ptr<double[]> mat = TestData::GetRandomDoublePointer(size);
+
+  std::unique_ptr<double[]> vec_x = TestData::GetRandomDoublePointer(col_size);
+  std::unique_ptr<double[]> vec_y = TestData::GetRandomDoublePointer(row_size);
+
+  std::unique_ptr<double[]> actual = MinusMatrixTimesVectorPlusVector(
+      mat.get(), row_size, col_size, vec_x.get(), vec_y.get());
+
+  // manually calculate
+  const double expect0 = -mat[0] * vec_x[0] - mat[1] * vec_x[1] + vec_y[0];
+  const double expect1 = -mat[2] * vec_x[0] - mat[3] * vec_x[1] + vec_y[1];
+  EXPECT_EQ(expect0, actual[0]);
+  EXPECT_EQ(expect1, actual[1]);
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/operator_binary.cc
+++ b/recipe/linear_algebra/operator_binary.cc
@@ -1,0 +1,54 @@
+#include "recipe/linear_algebra/operator_binary.h"
+#include <cassert>
+#include "recipe/linear_algebra/base.h"
+
+namespace recipe {
+namespace linear_algebra {
+std::unique_ptr<double[]> Multiply(const double* mat, const int row_size,
+                                   const int col_size, const double* vec) {
+  std::unique_ptr<double[]> data(new double[row_size]);
+  for (int row = 0; row < row_size; ++row) {
+    data[row] = 0.0;
+    for (int col = 0; col < col_size; ++col) {
+      data[row] += MATRIX(mat, col_size, row, col) * vec[col];
+    }
+  }
+  return data;
+}
+
+std::unique_ptr<double[]> Multiply(
+    const double* mat_lhs, const int row_size_lhs, const int col_size_lhs,
+    const double* mat_rhs, const int row_size_rhs, const int col_size_rhs) {
+  assert(col_size_lhs == row_size_rhs);
+  std::unique_ptr<double[]> data(new double[row_size_lhs * col_size_rhs]);
+  for (int row = 0; row < row_size_lhs; ++row) {
+    for (int col = 0; col < col_size_rhs; ++col) {
+      MATRIX(data, col_size_rhs, row, col) = 0.0;
+      for (int k = 0; k < col_size_lhs; ++k) {
+        MATRIX(data, col_size_rhs, row, col) +=
+            MATRIX(mat_lhs, col_size_lhs, row, k) *
+            MATRIX(mat_rhs, col_size_rhs, k, col);
+      }
+    }
+  }
+  return data;
+}
+
+Vector Multiply(const Matrix& mat, const Vector& vec) {
+  assert(mat.NumRow() == vec.Size());
+  const int row_size = mat.NumRow();
+  const int col_size = mat.NumCol();
+  std::unique_ptr<double[]> data =
+      Multiply(mat.Get(), row_size, col_size, vec.Get());
+  return Vector(row_size, std::move(data));
+}
+
+Matrix Multiply(const Matrix& mat_lhs, const Matrix& mat_rhs) {
+  std::unique_ptr<double[]> data =
+      Multiply(mat_lhs.Get(), mat_lhs.NumRow(), mat_lhs.NumCol(), mat_rhs.Get(),
+               mat_rhs.NumRow(), mat_rhs.NumCol());
+  return Matrix(mat_lhs.NumRow(), mat_rhs.NumCol(), std::move(data));
+}
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/operator_binary.h
+++ b/recipe/linear_algebra/operator_binary.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <memory>
+#include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/vector.h"
+
+namespace recipe {
+namespace linear_algebra {
+std::unique_ptr<double[]> Multiply(const double* mat, const int row_size,
+                                   const int col_size, const double* vec);
+std::unique_ptr<double[]> Multiply(
+    const double* mat_lhs, const int row_size_lhs, const int col_size_lhs,
+    const double* mat_rhs, const int row_size_rhs, const int col_size_rhs);
+
+Vector Multiply(const Matrix& mat, const Vector& vec);
+Matrix Multiply(const Matrix& mat_lhs, const Matrix& mat_rhs);
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/operator_binary_test.cc
+++ b/recipe/linear_algebra/operator_binary_test.cc
@@ -1,0 +1,54 @@
+#include "recipe/linear_algebra/operator_binary.h"
+#include <gtest/gtest.h>
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include "recipe/linear_algebra/test_util/test_data.h"
+#include "recipe/linear_algebra/util.h"
+
+namespace recipe {
+namespace linear_algebra {
+TEST(MultiplyTest, VectorArrayTimesVectorArray) {
+  const int row_size = 2;
+  const int col_size = 2;
+  const int size = row_size * col_size;
+  std::unique_ptr<double[]> vec = TestData::GetRandomDoublePointer(size);
+  std::unique_ptr<double[]> mat = TestData::GetRandomDoublePointer(size);
+  std::unique_ptr<double[]> actual =
+      Multiply(mat.get(), row_size, col_size, vec.get());
+  // manually solve
+  std::unique_ptr<double[]> expect = MakeDoubleArray({
+      // clang-format off
+    mat[0] * vec[0] + mat[1] * vec[1],
+    mat[2] * vec[0] + mat[3] * vec[1],
+      // clang-format on
+  });
+  EXPECT_ARRAY_ELEMENT_EQ(expect, actual, row_size);
+}
+
+TEST(MultiplyTest, MatrixArrayTimesMatrixArray) {
+  const int row_size = 2;
+  const int col_size = 2;
+  std::unique_ptr<double[]> mat_lhs = MakeDoubleArray({
+      // clang-format off
+                                                 1, 2,
+                                                 3, 4,
+      // clang-format on
+  });
+  std::unique_ptr<double[]> mat_rhs = MakeDoubleArray({
+      // clang-format off
+                                                 2, -1,
+                                                 1, -2,
+      // clang-format on
+  });
+  std::unique_ptr<double[]> actual = Multiply(
+      mat_lhs.get(), row_size, col_size, mat_rhs.get(), row_size, col_size);
+  // manually solve
+  std::unique_ptr<double[]> expect = MakeDoubleArray({
+      // clang-format off
+    2 + 2, -1 - 4,
+    6 + 4, -3,- 4,
+      // clang-format on
+  });
+  EXPECT_ARRAY_ELEMENT_EQ(expect, actual, row_size);
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/operator_unary.cc
+++ b/recipe/linear_algebra/operator_unary.cc
@@ -1,0 +1,15 @@
+#include "recipe/linear_algebra/operator_unary.h"
+#include <cmath>
+
+namespace recipe {
+namespace linear_algebra {
+double NormEuclid(const double* vec, const int size) {
+  double sum = 0.0;
+  for (int i = 0; i < size; ++i) {
+    sum += vec[i] * vec[i];
+  }
+  return std::sqrt(sum);
+  ;
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/operator_unary.h
+++ b/recipe/linear_algebra/operator_unary.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace recipe {
+namespace linear_algebra {
+double NormEuclid(const double* vec, const int size);
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/operator_unary_test.cc
+++ b/recipe/linear_algebra/operator_unary_test.cc
@@ -1,0 +1,16 @@
+#include "recipe/linear_algebra/operator_unary.h"
+#include <gtest/gtest.h>
+#include "recipe/linear_algebra/test_util/test_data.h"
+
+namespace recipe {
+namespace linear_algebra {
+TEST(NormEuclidTest, Example) {
+  const int size = 3;
+  const std::unique_ptr<double[]> data = TestData::GetRandomDoublePointer(size);
+  const double actual = NormEuclid(data.get(), size);
+  const double expect =
+      std::sqrt(data[0] * data[0] + data[1] * data[1] + data[2] * data[2]);
+  EXPECT_EQ(expect, actual);
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/test_util/gtest_assertion.h
+++ b/recipe/linear_algebra/test_util/gtest_assertion.h
@@ -2,9 +2,14 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/vector.h"
 #include "recipe/test_util/gtest_assertion.h"
 
 #define EXPECT_MATRIX_ELEMENT_NEAR(expect, actual, abs_error)             \
+  EXPECT_PRED_FORMAT3(recipe::linear_algebra::IsElementNearEqual, expect, \
+                      actual, abs_error)
+
+#define EXPECT_VECTOR_ELEMENT_NEAR(expect, actual, abs_error)             \
   EXPECT_PRED_FORMAT3(recipe::linear_algebra::IsElementNearEqual, expect, \
                       actual, abs_error)
 
@@ -39,6 +44,32 @@ inline ::testing::AssertionResult IsElementNearEqual(
                << expr2 << " evaluates to " << val2 << ", and\n"
                << abs_error_expr << " evaluates to " << abs_error << ".";
       }
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+inline ::testing::AssertionResult IsElementNearEqual(
+    const char* expr1, const char* expr2, const char* abs_error_expr,
+    const Vector& vec1, const Vector& vec2, const double abs_error) {
+  if (vec1.Size() != vec2.Size()) {
+    return ::testing::AssertionFailure()
+           << "size is not the same." << std::endl
+           << "expect.Size: " << vec1.Size() << std::endl
+           << "actual.Size: " << vec2.Size();
+  }
+  for (size_t row = 0; row < vec1.Size(); ++row) {
+    const double val1 = vec1(row);
+    const double val2 = vec2(row);
+    const double diff = std::fabs(val1 - val2);
+    if (diff > abs_error) {
+      return ::testing::AssertionFailure()
+             << "The difference between " << expr1 << " and " << expr2 << " is "
+             << diff << ", which exceeds " << abs_error_expr << ", where\n"
+             << expr1 << "(" << row << ") evaluates to " << val1 << ",\n"
+             << expr2 << "(" << row << ") evaluates to " << val2 << ", and\n"
+             << abs_error_expr << "(abs_error) evaluates to " << abs_error
+             << ".";
     }
   }
   return ::testing::AssertionSuccess();

--- a/recipe/linear_algebra/test_util/test_data.h
+++ b/recipe/linear_algebra/test_util/test_data.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <vector>
+#include "recipe/linear_algebra/base.h"
+#include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/vector.h"
 #include "recipe/test_util/test_data.h"
 
 namespace recipe {
@@ -44,20 +47,81 @@ class TestData {
   static std::unique_ptr<double[]> GetRandomDoublePointer(
       const std::size_t size) {
     std::unique_ptr<double[]> matrix(new double[size]);
-    std::vector<double> data = TestData::GetRandomNumbers(size);
-    std::copy(data.begin(), data.end(), matrix.get());
+    std::vector<double> values = TestData::GetRandomNumbers(size);
+    std::copy(values.begin(), values.end(), matrix.get());
     return matrix;
   }
 
-  static std::unique_ptr<double[]> GetRandomMatrix(const std::size_t row_size,
-                                                   const std::size_t col_size) {
+  static Matrix GetRandomMatrix(const int row_size, const int col_size) {
     const int size = row_size * col_size;
-    return GetRandomDoublePointer(size);
+    std::unique_ptr<double[]> data = GetRandomDoublePointer(size);
+    return Matrix(row_size, col_size, std::move(data));
+  }
+
+  static Vector GetRandomVector(const int size) {
+    std::unique_ptr<double[]> data = GetRandomDoublePointer(size);
+    return Vector(size, std::move(data));
   }
   // private function
  private:
   // private members
  private:
 };  // class TestData {
+
+///
+///
+///
+/// Exmaple:
+///
+/// ```c++
+///  LinearEquationGenerator generator(size);
+///  const Matrix& mat = generator.CreateMatrix();
+///  const Vector& vec = generator.CreateVector();
+///
+/// ```
+///
+/// The system is used in the paper
+/// Higham, N. J. (1997). Iterative refinement for linear systems and LAPACK.
+/// IMA Journal of Numerical Analysis. https://doi.org/10.1093/imanum/17.4.495
+///
+class LinearEquationGenerator {
+ public:
+  LinearEquationGenerator(const int size) : size_(size) {}
+
+  Matrix CreateMatrix() {
+    const int mat_size = size_ * size_;
+    std::unique_ptr<double[]> data(new double[mat_size]);
+    for (int k = 0; k < mat_size; ++k) {
+      const int row = k / size_;
+      const int col = k % size_;
+      data[k] = this->CreateMatrixElement(row, col);
+    }
+    return Matrix(size_, size_, std::move(data));
+  }
+
+  Vector CreateVector() {
+    std::unique_ptr<double[]> data(new double[size_]);
+    for (int k = 0; k < size_; ++k) {
+      data[k] = this->CreateVectorElement(k);
+    }
+    return Vector(size_, std::move(data));
+  }
+
+ private:
+  double CreateMatrixElement(const int row, const int col) {
+    const int r = row + 1;
+    const int c = col + 1;
+    const double alpha = 10e-5;
+    const double d = std::pow(alpha, 1.0 / r);
+    const double factor1 = std::pow(d * (2 / (size_ + 1.0)), 0.5);
+    const double factor2 = std::sin(r * c * PI / (size_ + 1.0));
+    return factor1 * factor2;
+  }
+
+  double CreateVectorElement(const int row) { return row + 1; }
+
+ private:
+  int size_;
+};
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/util.cc
+++ b/recipe/linear_algebra/util.cc
@@ -1,0 +1,31 @@
+#include <algorithm>
+#include <initializer_list>
+#include <memory>
+
+namespace recipe {
+namespace linear_algebra {
+
+std::unique_ptr<double[]> MakeDoubleArray(std::initializer_list<double> list) {
+  const int size = list.size();
+  std::unique_ptr<double[]> data(new double[size * size]);
+  std::copy(list.begin(), list.end(), data.get());
+  return data;
+}
+
+std::unique_ptr<double[]> GetIndentityMatrix(const int mat_size) {
+  std::unique_ptr<double[]> data(new double[mat_size * mat_size]);
+  std::fill(data.get(), data.get() + mat_size * mat_size, 0);
+  for (int i = 0; i < mat_size; ++i) {
+    data[i * mat_size + i] = 1.0;
+  }
+  return data;
+}
+
+std::unique_ptr<double[]> CopyDoubleArray(const double* original,
+                                          const int size) {
+  std::unique_ptr<double[]> data(new double[size]);
+  std::copy(original, original + size, data.get());
+  return data;
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/util.h
+++ b/recipe/linear_algebra/util.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <algorithm>
+#include <initializer_list>
+#include <memory>
+
+namespace recipe {
+namespace linear_algebra {
+std::unique_ptr<double[]> MakeDoubleArray(std::initializer_list<double> list);
+
+std::unique_ptr<double[]> GetIndentityMatrix(const int mat_size);
+
+std::unique_ptr<double[]> CopyDoubleArray(const double* orginal,
+                                          const int size);
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/util_test.cc
+++ b/recipe/linear_algebra/util_test.cc
@@ -1,0 +1,45 @@
+#include "recipe/linear_algebra/util.h"
+#include <gtest/gtest.h>
+#include <limits>
+
+namespace recipe {
+namespace linear_algebra {
+
+TEST(MakeDoubleArrayTest, Example) {
+  std::unique_ptr<double[]> data = MakeDoubleArray({
+      // clang-format off
+    1, 2, 3,
+    4, 5, 6,
+    7, 8, 9,
+      // clang-format on
+  });
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_NEAR(i + 1, data[i], std::numeric_limits<double>::epsilon());
+  }
+}
+
+TEST(GetIndentityMatrixTest, Example) {
+  const int size = 3;
+  std::unique_ptr<double[]> actual = GetIndentityMatrix(size);
+  std::unique_ptr<double[]> expect = MakeDoubleArray({
+      // clang-format off
+    1, 0, 0,
+    0, 1, 0,
+    0, 0, 1,
+      // clang-format on
+  });
+  for (int i = 0; i < size; ++i) {
+    EXPECT_NEAR(expect[i], actual[i], std::numeric_limits<double>::epsilon());
+  }
+}
+
+TEST(CopyDoubleArrayTest, Example) {
+  std::unique_ptr<double[]> data = MakeDoubleArray({1, 2, 3, 4, 5, 6, 7, 8, 9});
+  const int size = 9;
+  std::unique_ptr<double[]> actual = CopyDoubleArray(data.get(), size);
+  for (int i = 0; i < size; ++i) {
+    EXPECT_NEAR(i + 1.0, data[i], std::numeric_limits<double>::epsilon());
+  }
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/vector.cc
+++ b/recipe/linear_algebra/vector.cc
@@ -1,0 +1,80 @@
+#include "recipe/linear_algebra/vector.h"
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include "recipe/linear_algebra/util.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+Vector::Vector(const int size) : size_(size), data_(new double[size]) {}
+
+Vector::Vector(std::initializer_list<double> list)
+    : size_(list.size()), data_(new double[list.size()]) {
+  std::copy(list.begin(), list.end(), data_.get());
+}
+
+Vector::Vector(const int size, std::unique_ptr<double[]> data)
+    : size_(size), data_(std::move(data)) {}
+
+Vector::Vector(const Vector& other)
+    : size_(other.size_), data_(new double[other.size_]) {
+  std::copy(other.data_.get(), other.data_.get() + other.size_, data_.get());
+}
+
+double Vector::operator()(int i) const {
+  assert(0 <= i && i < size_);
+  return data_[i];
+}
+
+double& Vector::operator()(int i) {
+  assert(0 <= i && i < size_);
+  return data_[i];
+}
+
+Vector& Vector::operator+=(const Vector& other) {
+  for (int i = 0; i < other.size_; ++i) {
+    data_[i] += other.data_[i];
+  }
+  return *this;
+}
+
+Vector& Vector::operator=(const Vector& other) {
+  size_ = other.size_;
+  data_ = std::unique_ptr<double[]>(new double[size_]);
+  std::copy(other.data_.get(), other.data_.get() + size_, data_.get());
+  return *this;
+}
+
+bool Vector::operator==(const Vector& other) const {
+  if (size_ != other.size_) {
+    return false;
+  }
+  return std::equal(data_.get(), data_.get() + size_, other.data_.get());
+}
+
+//
+// free functions
+//
+Vector MakeUnitVector(const int size, const int pos) {
+  assert(pos < size);
+  std::unique_ptr<double[]> data(new double[size]);
+  std::fill(data.get(), data.get() + size, 0);
+  data[pos] = 1.0;
+  return Vector(size, std::move(data));
+}
+
+Vector MakeVector(std::initializer_list<double> list) {
+  std::unique_ptr<double[]> data = MakeDoubleArray(list);
+  return Vector(list.size(), std::move(data));
+}
+
+std::ostream& operator<<(std::ostream& os, const Vector& target) {
+  for (int i = 0; i < target.Size(); ++i) {
+    os << target(i) << ", ";
+  }
+  return os;
+}
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/vector.h
+++ b/recipe/linear_algebra/vector.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <iostream>
+#include <memory>
+
+namespace recipe {
+namespace linear_algebra {
+
+class Vector {
+ public:
+  explicit Vector(const int size);
+  explicit Vector(std::initializer_list<double> list);
+  Vector(const int size, const std::unique_ptr<double[]> data);
+  Vector(const Vector& other);
+
+  Vector& operator+=(const Vector& other);
+  double operator()(int i) const;
+  double& operator()(int i);
+  Vector& operator=(const Vector& other);
+  bool operator==(const Vector& other) const;
+  int Size() const { return size_; }
+  double* Get() { return data_.get(); }
+  const double* Get() const { return data_.get(); };
+
+ private:
+  int size_;
+  std::unique_ptr<double[]> data_;
+};
+
+Vector MakeUnitVector(const int size, const int pos);
+Vector MakeVector(std::initializer_list<double> list);
+std::ostream& operator<<(std::ostream& os, const Vector& target);
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/vector_test.cc
+++ b/recipe/linear_algebra/vector_test.cc
@@ -1,0 +1,106 @@
+#include "recipe/linear_algebra/vector.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include "recipe/linear_algebra/test_util/test_data.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+//
+// Vector class
+//
+TEST(VectorTest, CopyConstructor) {
+  Vector expect(3);
+  Vector actual(expect);
+
+  EXPECT_EQ(expect, actual);
+}
+
+TEST(VectorTest, ConstructorInitializer) {
+  Vector actual = Vector({1, 2, 3});
+
+  EXPECT_EQ(1, actual(0));
+  EXPECT_EQ(2, actual(1));
+  EXPECT_EQ(3, actual(2));
+}
+
+TEST(VectorTest, ConstructorData) {
+  const int size = 3;
+  std::unique_ptr<double[]> data = TestData::GetRandomDoublePointer(size);
+  std::unique_ptr<double[]> expect(new double[size]);
+  std::copy(data.get(), data.get() + size, expect.get());
+
+  Vector actual(size, std::move(data));
+  for (int i = 0; i < size; ++i) {
+    EXPECT_EQ(expect[i], actual(i));
+  }
+}
+
+TEST(VectorTest, Size) {
+  Vector actual(4);
+  EXPECT_EQ(4, actual.Size());
+}
+
+TEST(VectorTest, OperatorPlus) {
+  const Vector other = MakeVector({1, 2, 3, 4});
+  Vector actual = MakeVector({4, 3, 2, 1});
+
+  actual += other;
+  Vector expect = MakeVector({5, 5, 5, 5});
+  EXPECT_EQ(expect, actual);
+}
+
+TEST(VectorTest, OperatorParenthesis) {
+  Vector actual(3);
+  actual(1) = 1.0;
+
+  EXPECT_EQ(1.0, actual(1));
+}
+
+TEST(VectorTest, OperatorAsignment) {
+  Vector expect(3);
+  expect(0) = 1.0;
+
+  Vector actual = expect;
+  EXPECT_EQ(expect, actual);
+}
+
+#ifndef NDEBUG
+TEST(VectorTest, AssertIndexOutOfRange) {
+  Vector v(3);
+  EXPECT_DEATH(v(-1), "Assertion *");
+  EXPECT_DEATH(v(3), "Assertion *");
+}
+#endif
+
+//
+// Free functions
+//
+
+TEST(VectorTest, MakeUnitVector) {
+  Vector actual = MakeUnitVector(3, 1);
+  Vector expect({0.0, 1.0, 0.0});
+
+  EXPECT_EQ(expect, actual);
+}
+
+TEST(VectorTest, VectorOutputStreamOperator1) {
+  Vector data({1.0, 2.0, 3.0});
+
+  std::ostringstream actual;
+  actual << data;
+  std::string expect = "1, 2, 3, ";
+  EXPECT_STREQ(expect.c_str(), actual.str().c_str());
+}
+
+TEST(VectorTest, VectorOutputStreamOperator2) {
+  Vector data({1.5, 2.5, 3.5});
+
+  std::ostringstream actual;
+  actual << data;
+  std::string expect = "1.5, 2.5, 3.5, ";
+  EXPECT_STREQ(expect.c_str(), actual.str().c_str());
+}
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/sandbox/main_test.cc
+++ b/recipe/sandbox/main_test.cc
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
This PR introduces linear equation solver for a band-diagonal matrix. Linear equation systems can be solved with algorithms for general linear equation systems. However, if the size of the band is much smaller than the size of the matrix, the algorithms can be modified to solve linear equation systems generated by band diagonal matrix faster.
The modified algorithms can achieve computational complexity O(npq) where n is the size of the matrix, p is the size of upper diagonal and q is the size of the lower diagonal matrix. The idea behind the algorithms is the fact that the LU decomposition of the band diagonal matrix is also band-diagonal. Thus, we just need to compute the element in a part of the band.

## Directory structure
* `recipe/linear_algebra/`
    * directory for linear algebra module
* `recipe/linear_algebra/test_util/`
    * directory for test utilities to be specific to linear algebra module
    * for example, creating test data for some classes defined in linear algebra module, assertions which compare two objects which are of the same class
* `recipe/test_util/`
    * From the perspective of dependency management, `test_util` shouldn't include other modules.
    * This module contains utilities to run test cases and create tests such as creating `double array` whose values are randomly generated, etc.

## Reference
* Golub, Gene H., and Charles F. Van Loan. Matrix computations. Vol. 3. JHU Press, 2012.
