### PR TITLE
Send coverage reports to coveralls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,12 @@ To format all of code in the repository, you can run the script on the root of t
 ```
 
 ### bazel
+For OSX,
+
+```
+brew install buildifier
+```
+
 Check whether format error exists or not
 
 ```
@@ -123,6 +129,17 @@ Running multiple compilers in the same machine is sometimes annoying developers 
 For debugging in another compiler, we provide docker images.
 See `tools/docker/gcc` for the GCC compiler.
 
+## Coverage
+You need to install `gcov` and `lcov` to measure test coverages.
+We recommend to use the docker image.
+
+```
+./tools/docker/gcc/docker_build_ubuntu1604.sh
+./tools/docker/gcc/docker_run_ubuntu1604.sh
+bazel coverage //recipe/... --compilation_mode=dbg
+```
+
+There is no visualization of the result of the test coverage for now.
 
 ## TODO
 
@@ -141,8 +158,9 @@ See `tools/docker/gcc` for the GCC compiler.
     * [ ] benchmarks
 * [x] run unit tests
     * [google/googletest: Google Test](https://github.com/google/googletest)
-* [ ] coverage report
-    * coveralls/codecov
+* [x] coverage report
+    * coveralls
+        * currently, codeclimate does not support C++ repository.
 * [x] documentation
     * sphinx
 * [x] API document

--- a/ci/_lib/install_bazel.sh
+++ b/ci/_lib/install_bazel.sh
@@ -25,9 +25,11 @@ install_bazel_linux()
   fi
 
   # bazel's git_repository rule requires git
+  # if you run bazel-coverage command, you need to install lcov and gcov
   ${SUDO} apt-get install -y \
     software-properties-common \
     git \
+    lcov \
     curl
 
   # install JDK
@@ -57,5 +59,6 @@ install_bazel_osx()
   fi
 
   brew cask install homebrew/cask-versions/java8
-  brew install bazel
+  brew install \
+    bazel
 }

--- a/ci/_lib/install_coverage_misc.sh
+++ b/ci/_lib/install_coverage_misc.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+#
+#
+#
+install_coverage_misc_linux()
+{
+  if [[ ${_use_sudo} -eq 1 ]]; then
+    local SUDO="sudo"
+  fi
+
+  if [[ ${_do_update} -eq 1 ]]; then
+    ${SUDO} apt-get update
+  fi
+
+  # bazel-coverage command requires lcov and gcov
+  ${SUDO} apt-get install -y \
+    lcov \
+    curl
+
+  ${SUDO} curl https://bootstrap.pypa.io/get-pip.py -o $HOME/get-pip.py
+  ${SUDO} python $HOME/get-pip.py
+  ${SUDO} pip install cpp-coveralls
+}
+
+#
+# variables:
+#   * _do_update=1
+#
+install_coverage_misc_osx()
+{
+  if [[ ${_do_update} -eq 1 ]]; then
+    brew update
+  fi
+
+  brew install gcov
+  brew install lcov
+}

--- a/ci/build/build.sh
+++ b/ci/build/build.sh
@@ -24,6 +24,15 @@ run_test() {
     "//recipe/..."
 }
 
+run_coverage() {
+  bazel \
+    --output_base=$HOME/.cache/bazel \
+    coverage \
+    --test_output=errors \
+    ${BAZEL_OPTION} \
+    "//recipe/..."
+}
+
 run_benchmark() {
   ${PATH_TO_REPOSITORY}/tools/run_benchmark.sh
 }
@@ -54,11 +63,13 @@ fi
 # build and test
 #
 run_build
-run_test
 
 if is_covereage; then
-  # take coverage
-  echo "TODO: take coverage"
+  # bazel-coverage run tests so we can exclude to execute bazel-test
+  run_coverage
 elif is_benchmark; then
+  run_test
   run_benchmark
+else
+  run_test
 fi

--- a/ci/travis/after_success.sh
+++ b/ci/travis/after_success.sh
@@ -2,18 +2,30 @@
 
 set -e
 set -o pipefail
-set -o nounset
 if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
   set -x
 fi
 
+PATH_REPOSITORY=$(cd $(dirname ${0})/../..;pwd)
+
 if [[ `echo "${BUILD_TARGET}" | grep -E '(Coverage$|Coverage,)'` && "${TRAVIS_OS_NAME}" == "linux" ]]; then
-  # -g
-  pwd;
+  echo "$(pwd)"
+  gcov --version
+  lcov --version
+  ls -la
+
+  path_coverage_file="${PATH_REPOSITORY}/coverage.dat"
+  coverage_files=$(find ${PATH_REPOSITORY}/bazel-testlogs/recipe -name "coverage.dat" -a -not -empty)
+  #
+  # combine lcov capture files
+  #
+  lcov_args=$(echo "${coverage_files}" | awk '{print "-a " $0 }' | xargs)
+  echo "lcov ${lcov_args} --output-file ${path_coverage_file}"
+  lcov ${lcov_args} --output-file ${path_coverage_file}
+  #
+  # send report to coverall
+  # be sure to export COVERALLS_REPO_TOKEN env variable
+  #
   coveralls \
-    --verbose \
-    --include recipe \
-    --gcov-options '\-lp' \
-    --root . \
-    --build-root bazel-out/darwin-dbg/bin/recipe
+    --lcov-file ${path_coverage_file}
 fi

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -25,9 +25,10 @@ source ${PATH_TO_ROOT}/ci/travis/install_gcc.sh
 # we only measure coverage on Linux
 #
 if [[ `echo "${BUILD_TARGET}" | grep -E '(Coverage$|Coverage,)'` && "${TRAVIS_OS_NAME}" == "linux" ]]; then
-  PATH=~/.local/bin:${PATH};
-  pip install --user --upgrade pip;
-  pip install --user cpp-coveralls;
+  export PATH=~/.local/bin:${PATH};
+  # pip install --user --upgrade pip;
+  # pip install --user cpp-coveralls;
+  source ${PATH_TO_ROOT}/ci/travis/install_coveralls.sh
 fi
 
 echo ${PATH}

--- a/ci/travis/install_coveralls.sh
+++ b/ci/travis/install_coveralls.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/install_coverage_misc.sh
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+if [[ "$TRAVIS_OS_NAME" == "" ]]; then
+  echo '$TRAVIS_OS_NAME is not set.'
+  exit 1
+fi
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  _use_sudo=1 install_coverage_misc_linux
+fi
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  echo "install_coveralls.sh for OSX is not supported"
+  # install_coverage_misc_osx
+fi


### PR DESCRIPTION
## Summary
This PR enables to measure test coverage and send it to coveralls while Travis CI builds.
Coverages are measured whenever Travis CI runs integration tests.
You can check the coverage of your branch on the following website.

[i05nagai/numerical\_recipe \| Coveralls \- Test Coverage History & Statistics](https://coveralls.io/github/i05nagai/numerical_recipe)

## Choice of CI services
There are some SaaS CI such as `coveralls`, `codeclimate` and `codecov`.
`codeclimate` does not support repository written in C++.
Even though `codeclimate` accepts `lcov` or `gcov` reports, the results of the reports never show up on the site.
On the other hand, `coveralls` and `codecov` supports `lcov` or `gcov` reports.
I couldn't find a tool like `cpp-coveralls` to send coverage reports to `codecov`.

## How it sends
* `bazel-coverage` command generates `lcov` and `gcov` data in a directory generated by Bazel.
    * the reports are generated for each `cc_test` bazel rules
* Collect the coverage reports and combine them into single `lcov` tracefile with `lcov`
    * `cpp-coveralls` only supports sending a single `lcov` reports so combining is necessary
* Sending the generated report to Coveralls with `cpp-coveralls`
    * [eddyxu/cpp\-coveralls: Upload gcov results to coveralls\.io](https://github.com/eddyxu/cpp-coveralls)
    * `COVERALLS_REPO_TOKEN` environment variables are exported in Travic CI environment.

## Change
* Added some scripts to install `cpp-coveralls` and `lcov` to get test coverages reports.
* Modified scripts executed in Travis CI to measure test coverages

## TODO
* Some scripts does not support executing on OSX. Maybe future work.
