### PR TITLE
Add Householder QR decomposition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Executing tests for specific subpackages is also possible
 
 ```
 bazel test --test_output=errors //recipe/integrate:test
-bazel test --test_output=errors //recipe/sandbox:sandbox
+bazel test --test_output=errors //recipe/sandbox:test
 bazel test --test_output=errors //recipe/util:test
 ```
 

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -11,6 +11,14 @@ echo $LANG
 echo $LC_ALL
 ls -la
 
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  brew --version
+  # ignore auto-update failure
+  brew update || true
+  # disable auto-update
+  export HOMEBREW_NO_AUTO_UPDATE=1
+fi
+
 #
 # install
 # sourcing is required to export some variables

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -8,19 +8,29 @@ Algorithms
 Linear Algebra
 ---------------
 
- * [ ] Gauss-Jordan Elimination
- * [ ] Gaussian Elimination with Backsubstitution
- * [ ] LU Decomposition and Its Applications
- * [ ] Tridiagonal and Band-Diagonal Systems of Equations
- * [x] Band-Diagonal Gaussian Elimination Outer Product
- * [x] Upper triangular systems of linear equations
- * [x] Lower triangular systems of linear equations
- * [ ] Iterative Improvement of a Solution to Linear Equations
- * [ ] Singular Value Decomposition
- * [ ] Sparse Linear Systems
- * [ ] Vandermonde Matrices and Toeplitz Matrices
- * [ ] Cholesky Decomposition
- * [ ] QR Decomposition
+* [ ] Gauss-Jordan Elimination
+* [ ] Gaussian Elimination with Backsubstitution
+* [ ] LU Decomposition and Its Applications
+* [ ] Tridiagonal and Band-Diagonal Systems of Equations
+* [x] Band-Diagonal Gaussian Elimination Outer Product
+* [x] Upper triangular systems of linear equations
+* [x] Lower triangular systems of linear equations
+* [ ] Iterative Improvement of a Solution to Linear Equations
+* [ ] Singular Value Decomposition
+    * [ ] Golub-Kahan SVD
+* [ ] Sparse Linear Systems
+* [ ] Vandermonde Matrices and Toeplitz Matrices
+* [ ] Cholesky Decomposition
+* [ ] QR Decomposition
+    * [x] Householder QR
+    * [ ] Householder QR with pivotting
+    * [x] Givens QR
+    * [ ] Fast Givens QR
+    * [ ] Gram-Schmidt
+    * [ ] Modified Gram-Schmidt
+* [x] Householder Transformation
+  * [x] Householder Bidiagonalization
+* [x] Givens Rotation
 
 * Interpolation and Extrapolation
     * [ ] Polynomial Interpolation and Extrapolation

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -24,12 +24,12 @@ Linear Algebra
 * [ ] QR Decomposition
     * [x] Householder QR
     * [ ] Householder QR with pivotting
-    * [x] Givens QR
+    * [ ] Givens QR
     * [ ] Fast Givens QR
     * [ ] Gram-Schmidt
     * [ ] Modified Gram-Schmidt
 * [x] Householder Transformation
-  * [x] Householder Bidiagonalization
+    * [x] Householder Bidiagonalization
 * [x] Givens Rotation
 
 * Interpolation and Extrapolation
@@ -45,7 +45,7 @@ Linear Algebra
     * Elementary Algorithms
         * [ ] trapezoidal
     * [ ] Romberg Integration
-    * [o] Support Improper Integrals
+    * [ ] Support Improper Integrals
     * [ ] Quadrature by Variable Transformation
     * [ ] Gaussian Quadratures and Orthogonal Polynomials
     * [ ] Adaptive Quadrature

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Welcome to Numerical Recipe's documentation!
+Recipe's documentation.
 ============================================
 
 .. toctree::

--- a/docs/linear_algebra.rst
+++ b/docs/linear_algebra.rst
@@ -13,6 +13,15 @@ Triangular Matrix
    :project: recipe
    :path: ...
 
+
+Band-Diagonal Matrix
+---------------------
+
+.. doxygenfunction:: recipe::linear_algebra::GaussianEliminationOuterProductBandDiagonal(double *, const int, const int)
+   :project: recipe
+   :path: ...
+
+
 Matrix
 -------
 
@@ -30,5 +39,55 @@ Matrix
 
 
 .. doxygenfunction:: recipe::linear_algebra::MakeIdentityMatrix
+   :project: recipe
+   :path: ...
+
+Householder Transformation
+---------------------------
+
+.. doxygenfunction:: recipe::linear_algebra::ComputeHouseholderVector(const double *, const int, double *, double *)
+   :project: recipe
+   :path: ...
+
+.. doxygenfunction:: recipe::linear_algebra::ComputeHouseholderMatrix(const double *, const double, const int)
+   :project: recipe
+   :path: ...
+
+.. doxygenfunction:: recipe::linear_algebra::ComputeHouseholderBidiagonalization
+   :project: recipe
+   :path: ...
+
+
+QR decompositions
+-----------------
+
+.. doxygenfunction:: recipe::linear_algebra::ComputeHouseholderQR(double* mat_a, const int row_size, const int col_size)
+   :project: recipe
+   :path: ...
+
+.. doxygenfunction:: recipe::linear_algebra::ConvertHouseholderQRToQ(const double*, const double*, const int, const int);
+   :project: recipe
+   :path: ...
+
+.. doxygenfunction:: recipe::linear_algebra::ConvertHouseholderQRToR(const double*, const double*, const int, const int);
+   :project: recipe
+   :path: ...
+
+.. doxygenfunction:: recipe::linear_algebra::ConvertHouseholderQRToQR(const double*, const double*, const int, const int);
+   :project: recipe
+   :path: ...
+
+Gievns Rotation
+---------------
+
+.. doxygenfunction:: recipe::linear_algebra::ComputeGivensRotationParameters
+   :project: recipe
+   :path: ...
+
+.. doxygenfunction:: recipe::linear_algebra::MultiplyGivensRotation(const int, const int, const std::pair<double, double>&, double *, const int, const int)
+   :project: recipe
+   :path: ...
+
+.. doxygenfunction:: recipe::linear_algebra::MultiplyGivensRotation(double *, const int, const int, const int, const int, const std::pair<double, double>&)
    :project: recipe
    :path: ...

--- a/docs/test_util.rst
+++ b/docs/test_util.rst
@@ -28,3 +28,10 @@ Gtest assersions
    :project: recipe
    :path: ...
 
+.. doxygendefine:: EXPECT_ARRAY_ELEMENT_NEAR
+   :project: recipe
+   :path: ...
+
+.. doxygendefine:: EXPECT_ASSERT_FAIL
+   :project: recipe
+   :path: ...

--- a/docs/test_util.rst
+++ b/docs/test_util.rst
@@ -15,3 +15,16 @@ Classes and functions to generate data for testing.
    :protected-members:
    :private-members:
    :undoc-members:
+
+
+Gtest assersions
+----------------
+
+.. doxygendefine:: EXPECT_VECTOR_ELEMENT_EQ
+   :project: recipe
+   :path: ...
+
+.. doxygendefine:: EXPECT_ARRAY_ELEMENT_EQ
+   :project: recipe
+   :path: ...
+

--- a/recipe/linear_algebra/givens_rotation.cc
+++ b/recipe/linear_algebra/givens_rotation.cc
@@ -1,0 +1,73 @@
+#include "recipe/linear_algebra/givens_rotation.h"
+#include "recipe/linear_algebra/base.h"
+#include <cassert>
+#include <cmath>
+
+namespace recipe {
+namespace linear_algebra {
+
+std::pair<double, double>
+ComputeGivensRotationParameters(const double val1, const double val2)
+{
+  if (val2 == 0.0) {
+    // already rotated
+    return std::make_pair(1.0, 0.0);
+  } else {
+    if (val2 > val1) {
+      const double factor = - val1 / val2;
+      const double sin_term = 1.0 / std::sqrt(1.0 + factor * factor);
+      const double cos_term = sin_term * factor;
+      return std::make_pair(cos_term, sin_term);
+    } else {
+      const double factor = - val2 / val1;
+      const double cos_term = 1.0 / std::sqrt(1.0 + factor * factor);
+      const double sin_term = cos_term * factor;
+      return std::make_pair(cos_term, sin_term);
+    }
+  }
+}
+
+void MultiplyGivensRotation(
+    const int givens_index1,
+    const int givens_index2,
+    const std::pair<double, double>& givens_params,
+    double* mat_a,
+    const int row_size,
+    const int col_size)
+{
+  assert(0 <= givens_index1 && givens_index1 < givens_index2);
+  assert(givens_index2 < row_size);
+  for (int col = 0; col < col_size; ++col) {
+    const double elem1 = MATRIX(mat_a, col_size, givens_index1, col);
+    const double elem2 = MATRIX(mat_a, col_size, givens_index2, col);
+    MATRIX(mat_a, col_size, givens_index1, col)
+      = givens_params.first * elem1 - givens_params.second * elem2;
+    MATRIX(mat_a, col_size, givens_index2, col)
+      = givens_params.second * elem1 + givens_params.first * elem2;
+  }
+}
+
+void MultiplyGivensRotation(
+    double* mat_a,
+    const int row_size,
+    const int col_size,
+    const int givens_index1,
+    const int givens_index2,
+    const std::pair<double, double>& givens_params)
+{
+  assert(0 <= givens_index1 && givens_index1 < givens_index2);
+  assert(givens_index2 < col_size);
+  for (int row = 0; row < row_size; ++row) {
+    const double elem1 = MATRIX(mat_a, col_size, row, givens_index1);
+    const double elem2 = MATRIX(mat_a, col_size, row, givens_index2);
+    MATRIX(mat_a, col_size, row, givens_index1)
+      = givens_params.first * elem1 - givens_params.second * elem2;
+    MATRIX(mat_a, col_size, row, givens_index2)
+      = givens_params.second * elem1 + givens_params.first * elem2;
+  }
+}
+
+}  // namespace linear_algebra
+}  // namespace recipe
+
+

--- a/recipe/linear_algebra/givens_rotation.cc
+++ b/recipe/linear_algebra/givens_rotation.cc
@@ -1,25 +1,24 @@
 #include "recipe/linear_algebra/givens_rotation.h"
-#include "recipe/linear_algebra/base.h"
 #include <cassert>
 #include <cmath>
+#include "recipe/linear_algebra/base.h"
 
 namespace recipe {
 namespace linear_algebra {
 
-std::pair<double, double>
-ComputeGivensRotationParameters(const double val1, const double val2)
-{
+std::pair<double, double> ComputeGivensRotationParameters(const double val1,
+                                                          const double val2) {
   if (val2 == 0.0) {
     // already rotated
     return std::make_pair(1.0, 0.0);
   } else {
     if (val2 > val1) {
-      const double factor = - val1 / val2;
+      const double factor = -val1 / val2;
       const double sin_term = 1.0 / std::sqrt(1.0 + factor * factor);
       const double cos_term = sin_term * factor;
       return std::make_pair(cos_term, sin_term);
     } else {
-      const double factor = - val2 / val1;
+      const double factor = -val2 / val1;
       const double cos_term = 1.0 / std::sqrt(1.0 + factor * factor);
       const double sin_term = cos_term * factor;
       return std::make_pair(cos_term, sin_term);
@@ -27,47 +26,37 @@ ComputeGivensRotationParameters(const double val1, const double val2)
   }
 }
 
-void MultiplyGivensRotation(
-    const int givens_index1,
-    const int givens_index2,
-    const std::pair<double, double>& givens_params,
-    double* mat_a,
-    const int row_size,
-    const int col_size)
-{
+void MultiplyGivensRotation(const int givens_index1, const int givens_index2,
+                            const std::pair<double, double>& givens_params,
+                            double* mat_a, const int row_size,
+                            const int col_size) {
   assert(0 <= givens_index1 && givens_index1 < givens_index2);
   assert(givens_index2 < row_size);
   for (int col = 0; col < col_size; ++col) {
     const double elem1 = MATRIX(mat_a, col_size, givens_index1, col);
     const double elem2 = MATRIX(mat_a, col_size, givens_index2, col);
-    MATRIX(mat_a, col_size, givens_index1, col)
-      = givens_params.first * elem1 - givens_params.second * elem2;
-    MATRIX(mat_a, col_size, givens_index2, col)
-      = givens_params.second * elem1 + givens_params.first * elem2;
+    MATRIX(mat_a, col_size, givens_index1, col) =
+        givens_params.first * elem1 - givens_params.second * elem2;
+    MATRIX(mat_a, col_size, givens_index2, col) =
+        givens_params.second * elem1 + givens_params.first * elem2;
   }
 }
 
-void MultiplyGivensRotation(
-    double* mat_a,
-    const int row_size,
-    const int col_size,
-    const int givens_index1,
-    const int givens_index2,
-    const std::pair<double, double>& givens_params)
-{
+void MultiplyGivensRotation(double* mat_a, const int row_size,
+                            const int col_size, const int givens_index1,
+                            const int givens_index2,
+                            const std::pair<double, double>& givens_params) {
   assert(0 <= givens_index1 && givens_index1 < givens_index2);
   assert(givens_index2 < col_size);
   for (int row = 0; row < row_size; ++row) {
     const double elem1 = MATRIX(mat_a, col_size, row, givens_index1);
     const double elem2 = MATRIX(mat_a, col_size, row, givens_index2);
-    MATRIX(mat_a, col_size, row, givens_index1)
-      = givens_params.first * elem1 - givens_params.second * elem2;
-    MATRIX(mat_a, col_size, row, givens_index2)
-      = givens_params.second * elem1 + givens_params.first * elem2;
+    MATRIX(mat_a, col_size, row, givens_index1) =
+        givens_params.first * elem1 - givens_params.second * elem2;
+    MATRIX(mat_a, col_size, row, givens_index2) =
+        givens_params.second * elem1 + givens_params.first * elem2;
   }
 }
 
 }  // namespace linear_algebra
 }  // namespace recipe
-
-

--- a/recipe/linear_algebra/givens_rotation.h
+++ b/recipe/linear_algebra/givens_rotation.h
@@ -1,0 +1,74 @@
+#pragma once
+#include <utility>
+
+namespace recipe {
+namespace linear_algebra {
+
+/// @brief Compute $c$ and $s$ which satisfy
+///
+/// $$
+/// \\left(
+///     \\begin{array}{cc}
+///         c & s \\\\\
+///         -s & c
+///     \\end{array}
+/// \\right)^{\\mathrm{T}}
+/// \\left(
+///     \\begin{array}{c}
+///         a \\\\\
+///         b
+///     \\end{array}
+///  \\right)
+///  =
+///  \\left(
+///      \\begin{array}{c}
+///          r \\\\\
+///          0
+///      \\end{array}
+///  \\right)
+///  .
+///  $$
+///
+/// @param val1 value $a$
+/// @param val2 value $b$
+///
+/// @return values $c$ and $s$.
+/// 
+std::pair<double, double>
+ComputeGivensRotationParameters(const double val1, const double val2);
+
+/// @brief Multiply Givens rotations from left to $A$. Compute $G(i, j, c, s)^{\\mathrm{T}}A$.
+///
+/// @param givens_index1 Givens rotation position $i$.
+/// @param givens_index2 Givens rotation position $j$. Must be $i < j$.
+/// @param givens_params Givens rotation parameter $(c, s)$.
+/// @param mat_a matrix $A$. Overwritten by $G(i, j, c, s)A$.
+/// @param row_size
+/// @param col_size
+/// 
+void MultiplyGivensRotation(
+    const int givens_index1,
+    const int givens_index2,
+    const std::pair<double, double>& givens_params,
+    double* mat_a,
+    const int row_size,
+    const int col_size);
+
+/// @brief Multiply Givens rotations from right to $A$. Compute $AG(i, j, c, s)$.
+///
+/// @param mat_a matrix $A$. Overwritten by $AG(i, j, c, s)$.
+/// @param row_size
+/// @param col_size
+/// @param givens_index1 Givens rotation position $i$.
+/// @param givens_index2 Givens rotation position $j$. Must be $i < j$.
+/// @param givens_params Givens rotation parameter $(c, s)$.
+/// 
+void MultiplyGivensRotation(
+    double* mat_a,
+    const int row_size,
+    const int col_size,
+    const int givens_index1,
+    const int givens_index2,
+    const std::pair<double, double>& givens_params);
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/givens_rotation.h
+++ b/recipe/linear_algebra/givens_rotation.h
@@ -33,11 +33,12 @@ namespace linear_algebra {
 /// @param val2 value $b$
 ///
 /// @return values $c$ and $s$.
-/// 
-std::pair<double, double>
-ComputeGivensRotationParameters(const double val1, const double val2);
+///
+std::pair<double, double> ComputeGivensRotationParameters(const double val1,
+                                                          const double val2);
 
-/// @brief Multiply Givens rotations from left to $A$. Compute $G(i, j, c, s)^{\\mathrm{T}}A$.
+/// @brief Multiply Givens rotations from left to $A$. Compute $G(i, j, c,
+/// s)^{\\mathrm{T}}A$.
 ///
 /// @param givens_index1 Givens rotation position $i$.
 /// @param givens_index2 Givens rotation position $j$. Must be $i < j$.
@@ -45,16 +46,14 @@ ComputeGivensRotationParameters(const double val1, const double val2);
 /// @param mat_a matrix $A$. Overwritten by $G(i, j, c, s)A$.
 /// @param row_size
 /// @param col_size
-/// 
-void MultiplyGivensRotation(
-    const int givens_index1,
-    const int givens_index2,
-    const std::pair<double, double>& givens_params,
-    double* mat_a,
-    const int row_size,
-    const int col_size);
+///
+void MultiplyGivensRotation(const int givens_index1, const int givens_index2,
+                            const std::pair<double, double>& givens_params,
+                            double* mat_a, const int row_size,
+                            const int col_size);
 
-/// @brief Multiply Givens rotations from right to $A$. Compute $AG(i, j, c, s)$.
+/// @brief Multiply Givens rotations from right to $A$. Compute $AG(i, j, c,
+/// s)$.
 ///
 /// @param mat_a matrix $A$. Overwritten by $AG(i, j, c, s)$.
 /// @param row_size
@@ -62,13 +61,10 @@ void MultiplyGivensRotation(
 /// @param givens_index1 Givens rotation position $i$.
 /// @param givens_index2 Givens rotation position $j$. Must be $i < j$.
 /// @param givens_params Givens rotation parameter $(c, s)$.
-/// 
-void MultiplyGivensRotation(
-    double* mat_a,
-    const int row_size,
-    const int col_size,
-    const int givens_index1,
-    const int givens_index2,
-    const std::pair<double, double>& givens_params);
+///
+void MultiplyGivensRotation(double* mat_a, const int row_size,
+                            const int col_size, const int givens_index1,
+                            const int givens_index2,
+                            const std::pair<double, double>& givens_params);
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/givens_rotation_test.cc
+++ b/recipe/linear_algebra/givens_rotation_test.cc
@@ -17,7 +17,11 @@ TEST(ComputeGivensRotationParametersTest, Example) {
 
 TEST(MultiplyGivensRotationTest, MultiplyFromLeftExample) {
   double mat_a[] = {
-      1.0, -1.0, 4.0, 1.0, 4.0, -2.0, 1.0, 4.0, 2.0, 1.0, -1.0, 0.0,
+      // clang-format off
+      1.0, -1.0, 4.0, 1.0,
+      4.0, -2.0, 1.0, 4.0,
+      2.0, 1.0, -1.0, 0.0,
+      // clang-format on
   };
   const int row_size = 4;
   const int col_size = 3;
@@ -29,25 +33,22 @@ TEST(MultiplyGivensRotationTest, MultiplyFromLeftExample) {
                          row_size, col_size);
 
   double expect[] = {
-      1.0,
-      -1.0,
-      4.0,
-      1.0,
-      4.0,
-      -2.0,
-      2.0 / std::sqrt(2.0),
-      3.0 / std::sqrt(2.0),
-      2.0 / std::sqrt(2.0),
-      0.0,
-      -5.0 / std::sqrt(2.0),
-      -2.0 / std::sqrt(2.0),
+      // clang-format off
+      1.0, -1.0, 4.0, 1.0,
+      4.0, -2.0, 2.0 / std::sqrt(2.0), 3.0 / std::sqrt(2.0),
+      2.0 / std::sqrt(2.0), 0.0, -5.0 / std::sqrt(2.0), -2.0 / std::sqrt(2.0),
+      // clang-format on
   };
   EXPECT_ARRAY_ELEMENT_EQ(expect, mat_a, row_size * col_size);
 }
 
 TEST(MultiplyGivensRotationTest, MultiplyFromRightExample) {
   double mat_a[] = {
-      1.0, -1.0, 4.0, 1.0, 4.0, -2.0, 1.0, 4.0, 2.0, 1.0, -1.0, 0.0,
+      // clang-format off
+      1.0, -1.0, 4.0, 1.0,
+      4.0, -2.0, 1.0, 4.0,
+      2.0, 1.0, -1.0, 0.0,
+      // clang-format on
   };
   const int row_size = 4;
   const int col_size = 3;
@@ -58,11 +59,13 @@ TEST(MultiplyGivensRotationTest, MultiplyFromRightExample) {
   MultiplyGivensRotation(mat_a, row_size, col_size, givens_index1,
                          givens_index2, givens_params);
 
+  const double sq17 = std::sqrt(17.0);
   double expect[] = {
-      1.0, (1.0 + 16.0) / std::sqrt(17.0), 0.0,
-      1.0, (-4.0 - 8.0) / std::sqrt(17.0), (-16.0 + 2.0) / std::sqrt(17.0),
-      1.0, (-4.0 + 8.0) / std::sqrt(17.0), (-16.0 - 2.0) / std::sqrt(17.0),
-      1.0, (1.0 - 0.0) / std::sqrt(17.0),  (4.0 + 0.0) / std::sqrt(17.0),
+      // clang-format off
+      1.0, (1.0 + 16.0) / sq17, 0.0, 1.0,
+      (-4.0 - 8.0) / sq17, (-16.0 + 2.0) / sq17, 1.0, (-4.0 + 8.0) / sq17,
+      (-16.0 - 2.0) / sq17, 1.0, (1.0 - 0.0) / sq17,  (4.0 + 0.0) / sq17,
+      // clang-format on
   };
   EXPECT_ARRAY_ELEMENT_EQ(expect, mat_a, row_size * col_size);
 }

--- a/recipe/linear_algebra/givens_rotation_test.cc
+++ b/recipe/linear_algebra/givens_rotation_test.cc
@@ -1,0 +1,71 @@
+#include "recipe/linear_algebra/givens_rotation.h"
+#include "recipe/test_util/test_util.h"
+#include <gtest/gtest.h>
+#include <cmath>
+
+namespace recipe {
+namespace linear_algebra {
+TEST(ComputeGivensRotationParametersTest, Example)
+{
+  const double val1 = 1.0;
+  const double val2 = 1.0;
+  const std::pair<double, double> actual
+    = ComputeGivensRotationParameters(val1, val2);
+  
+  EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2.0), actual.first);
+  EXPECT_DOUBLE_EQ(-1.0 / std::sqrt(2.0), actual.second);
+}
+
+TEST(MultiplyGivensRotationTest, MultiplyFromLeftExample)
+{
+  double mat_a[] = {
+    1.0, -1.0, 4.0,
+    1.0, 4.0, -2.0,
+    1.0, 4.0, 2.0,
+    1.0, -1.0, 0.0,
+  };
+  const int row_size = 4;
+  const int col_size = 3;
+  const int givens_index1 = 2;
+  const int givens_index2 = 3;
+  std::pair<double, double> givens_params 
+    = std::make_pair(1.0 / std::sqrt(2.0), -1.0 / std::sqrt(2.0));
+  MultiplyGivensRotation(
+      givens_index1, givens_index2, givens_params, mat_a, row_size, col_size);
+
+  double expect[] = {
+    1.0, -1.0, 4.0,
+    1.0, 4.0, -2.0,
+    2.0 / std::sqrt(2.0), 3.0 / std::sqrt(2.0), 2.0 / std::sqrt(2.0),
+    0.0, -5.0 / std::sqrt(2.0), -2.0 / std::sqrt(2.0),
+  };
+  EXPECT_ARRAY_ELEMENT_EQ(expect, mat_a, row_size * col_size);
+}
+
+TEST(MultiplyGivensRotationTest, MultiplyFromRightExample)
+{
+  double mat_a[] = {
+    1.0, -1.0, 4.0,
+    1.0, 4.0, -2.0,
+    1.0, 4.0, 2.0,
+    1.0, -1.0, 0.0,
+  };
+  const int row_size = 4;
+  const int col_size = 3;
+  const int givens_index1 = 1;
+  const int givens_index2 = 2;
+  std::pair<double, double> givens_params 
+    = std::make_pair(-1.0 / std::sqrt(17.0), -4.0 / std::sqrt(17.0));
+  MultiplyGivensRotation(
+      mat_a, row_size, col_size, givens_index1, givens_index2, givens_params);
+
+  double expect[] = {
+    1.0, (1.0 + 16.0) / std::sqrt(17.0), 0.0,
+    1.0, (-4.0 - 8.0) / std::sqrt(17.0), (-16.0 + 2.0) / std::sqrt(17.0),
+    1.0, (-4.0 + 8.0) / std::sqrt(17.0), (-16.0 - 2.0) / std::sqrt(17.0),
+    1.0, (1.0 - 0.0) / std::sqrt(17.0), (4.0 + 0.0) / std::sqrt(17.0),
+  };
+  EXPECT_ARRAY_ELEMENT_EQ(expect, mat_a, row_size * col_size);
+}
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/givens_rotation_test.cc
+++ b/recipe/linear_algebra/givens_rotation_test.cc
@@ -1,69 +1,68 @@
 #include "recipe/linear_algebra/givens_rotation.h"
-#include "recipe/test_util/test_util.h"
 #include <gtest/gtest.h>
 #include <cmath>
+#include "recipe/test_util/test_util.h"
 
 namespace recipe {
 namespace linear_algebra {
-TEST(ComputeGivensRotationParametersTest, Example)
-{
+TEST(ComputeGivensRotationParametersTest, Example) {
   const double val1 = 1.0;
   const double val2 = 1.0;
-  const std::pair<double, double> actual
-    = ComputeGivensRotationParameters(val1, val2);
-  
+  const std::pair<double, double> actual =
+      ComputeGivensRotationParameters(val1, val2);
+
   EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2.0), actual.first);
   EXPECT_DOUBLE_EQ(-1.0 / std::sqrt(2.0), actual.second);
 }
 
-TEST(MultiplyGivensRotationTest, MultiplyFromLeftExample)
-{
+TEST(MultiplyGivensRotationTest, MultiplyFromLeftExample) {
   double mat_a[] = {
-    1.0, -1.0, 4.0,
-    1.0, 4.0, -2.0,
-    1.0, 4.0, 2.0,
-    1.0, -1.0, 0.0,
+      1.0, -1.0, 4.0, 1.0, 4.0, -2.0, 1.0, 4.0, 2.0, 1.0, -1.0, 0.0,
   };
   const int row_size = 4;
   const int col_size = 3;
   const int givens_index1 = 2;
   const int givens_index2 = 3;
-  std::pair<double, double> givens_params 
-    = std::make_pair(1.0 / std::sqrt(2.0), -1.0 / std::sqrt(2.0));
-  MultiplyGivensRotation(
-      givens_index1, givens_index2, givens_params, mat_a, row_size, col_size);
+  std::pair<double, double> givens_params =
+      std::make_pair(1.0 / std::sqrt(2.0), -1.0 / std::sqrt(2.0));
+  MultiplyGivensRotation(givens_index1, givens_index2, givens_params, mat_a,
+                         row_size, col_size);
 
   double expect[] = {
-    1.0, -1.0, 4.0,
-    1.0, 4.0, -2.0,
-    2.0 / std::sqrt(2.0), 3.0 / std::sqrt(2.0), 2.0 / std::sqrt(2.0),
-    0.0, -5.0 / std::sqrt(2.0), -2.0 / std::sqrt(2.0),
+      1.0,
+      -1.0,
+      4.0,
+      1.0,
+      4.0,
+      -2.0,
+      2.0 / std::sqrt(2.0),
+      3.0 / std::sqrt(2.0),
+      2.0 / std::sqrt(2.0),
+      0.0,
+      -5.0 / std::sqrt(2.0),
+      -2.0 / std::sqrt(2.0),
   };
   EXPECT_ARRAY_ELEMENT_EQ(expect, mat_a, row_size * col_size);
 }
 
-TEST(MultiplyGivensRotationTest, MultiplyFromRightExample)
-{
+TEST(MultiplyGivensRotationTest, MultiplyFromRightExample) {
   double mat_a[] = {
-    1.0, -1.0, 4.0,
-    1.0, 4.0, -2.0,
-    1.0, 4.0, 2.0,
-    1.0, -1.0, 0.0,
+      1.0, -1.0, 4.0, 1.0, 4.0, -2.0, 1.0, 4.0, 2.0, 1.0, -1.0, 0.0,
   };
   const int row_size = 4;
   const int col_size = 3;
   const int givens_index1 = 1;
   const int givens_index2 = 2;
-  std::pair<double, double> givens_params 
-    = std::make_pair(-1.0 / std::sqrt(17.0), -4.0 / std::sqrt(17.0));
-  MultiplyGivensRotation(
-      mat_a, row_size, col_size, givens_index1, givens_index2, givens_params);
+  std::pair<double, double> givens_params =
+      std::make_pair(-1.0 / std::sqrt(17.0), -4.0 / std::sqrt(17.0));
+  MultiplyGivensRotation(mat_a, row_size, col_size, givens_index1,
+                         givens_index2, givens_params);
 
   double expect[] = {
-    1.0, (1.0 + 16.0) / std::sqrt(17.0), 0.0,
-    1.0, (-4.0 - 8.0) / std::sqrt(17.0), (-16.0 + 2.0) / std::sqrt(17.0),
-    1.0, (-4.0 + 8.0) / std::sqrt(17.0), (-16.0 - 2.0) / std::sqrt(17.0),
-    1.0, (1.0 - 0.0) / std::sqrt(17.0), (4.0 + 0.0) / std::sqrt(17.0),
+      1.0, (1.0 + 16.0) / std::sqrt(17.0), 0.0,
+      1.0, (-4.0 - 8.0) / std::sqrt(17.0), (-16.0 + 2.0) / std::sqrt(17.0),
+      1.0, (-4.0 + 8.0) / std::sqrt(17.0), (-16.0 - 2.0) / std::sqrt(17.0),
+      1.0, (1.0 - 0.0) / std::sqrt(17.0),  (4.0 + 0.0) / std::sqrt(17.0),
   };
   EXPECT_ARRAY_ELEMENT_EQ(expect, mat_a, row_size * col_size);
 }

--- a/recipe/linear_algebra/householder.cc
+++ b/recipe/linear_algebra/householder.cc
@@ -1,21 +1,18 @@
 #include "recipe/linear_algebra/householder.h"
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <numeric>
 #include <stdexcept>
-#include <algorithm>
-#include "recipe/linear_algebra/operator_binary.h"
 #include "recipe/linear_algebra/base.h"
+#include "recipe/linear_algebra/operator_binary.h"
 
 namespace recipe {
 namespace linear_algebra {
 
-void ComputeHouseholderVector(
-    const double* vec_x,
-    const int size_vec,
-    double* householder_vec,
-    double* householder_coeff)
-{
+void ComputeHouseholderVector(const double* vec_x, const int size_vec,
+                              double* householder_vec,
+                              double* householder_coeff) {
   assert(size_vec > 0);
   const double sum0 = InnerProduct(vec_x + 1, vec_x + 1, size_vec - 1);
   for (int i = 0; i < size_vec; ++i) {
@@ -31,11 +28,11 @@ void ComputeHouseholderVector(
     if (vec_x[0] <= 0.0) {
       householder_vec[0] = vec_x[0] - norm;
     } else {
-      householder_vec[0] = - sum0 / (vec_x[0] + norm);
+      householder_vec[0] = -sum0 / (vec_x[0] + norm);
     }
     // update coeff
-    *householder_coeff = 2.0 * householder_vec[0] * householder_vec[0]
-      / (sum0 + householder_vec[0] * householder_vec[0]);
+    *householder_coeff = 2.0 * householder_vec[0] * householder_vec[0] /
+                         (sum0 + householder_vec[0] * householder_vec[0]);
     for (int i = size_vec - 1; i >= 0; --i) {
       householder_vec[i] /= householder_vec[0];
     }
@@ -43,67 +40,58 @@ void ComputeHouseholderVector(
 }
 
 std::unique_ptr<double[]> ComputeHouseholderMatrix(
-    const double* householder_vec,
-    const double householder_coeff,
-    const int size)
-{
+    const double* householder_vec, const double householder_coeff,
+    const int size) {
   std::unique_ptr<double[]> mat_data(new double[size * size]);
   for (int row = 0; row < size; ++row) {
     for (int col = 0; col < size; ++col) {
       if (row == col) {
-        MATRIX(mat_data, size, row, col) 
-          = 1.0 - householder_coeff * householder_vec[row] * householder_vec[col];
+        MATRIX(mat_data, size, row, col) = 1.0 - householder_coeff *
+                                                     householder_vec[row] *
+                                                     householder_vec[col];
       } else {
-        MATRIX(mat_data, size, row, col) 
-          = - householder_coeff * householder_vec[row] * householder_vec[col];
+        MATRIX(mat_data, size, row, col) =
+            -householder_coeff * householder_vec[row] * householder_vec[col];
       }
     }
   }
   return mat_data;
 }
 
-void ComputeHouseholderVector(
-    const Vector vec_x,
-    Vector* householder_vec,
-    double* householder_coeff)
-{
+void ComputeHouseholderVector(const Vector vec_x, Vector* householder_vec,
+                              double* householder_coeff) {
   const int size = vec_x.Size();
-  ComputeHouseholderVector(
-      vec_x.Get(), size, householder_vec->Get(), householder_coeff);
+  ComputeHouseholderVector(vec_x.Get(), size, householder_vec->Get(),
+                           householder_coeff);
 }
 
-Matrix ComputeHouseholderMatrix(
-    const Vector householder_vec,
-    const double householder_coeff)
-{
+Matrix ComputeHouseholderMatrix(const Vector householder_vec,
+                                const double householder_coeff) {
   const int size = householder_vec.Size();
-  std::unique_ptr<double[]> data = ComputeHouseholderMatrix(
-      householder_vec.Get(), householder_coeff, size);
+  std::unique_ptr<double[]> data =
+      ComputeHouseholderMatrix(householder_vec.Get(), householder_coeff, size);
   return Matrix(size, size, std::move(data));
 }
 
-void MultiplyHouseholderMatrixFromLeft(
-    double* mat_a,
-    const int row_size,
-    const int col_size,
-    const double* householder_vec,
-    const double householder_coeff,
-    const int vec_size)
-{
+void MultiplyHouseholderMatrixFromLeft(double* mat_a, const int row_size,
+                                       const int col_size,
+                                       const double* householder_vec,
+                                       const double householder_coeff,
+                                       const int vec_size) {
   // TODO: Support row_size < col_size
   assert(row_size >= col_size);
-  std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
-      householder_vec, householder_coeff, vec_size);
+  std::unique_ptr<double[]> householder_mat =
+      ComputeHouseholderMatrix(householder_vec, householder_coeff, vec_size);
   const int offset = row_size - vec_size;
   // (I - beta vv^{T})
   // A[row_size-vec_size:(row_size-1), col_size-vec_size:(col_size-1)]
   double mat_temp[row_size * col_size];
   for (int row = offset; row < row_size; ++row) {
-    for (int col = offset; col< col_size; ++col) {
+    for (int col = offset; col < col_size; ++col) {
       double sum = 0.0;
       for (int k = 0; k < vec_size; ++k) {
-        sum += (MATRIX(householder_mat, vec_size, row - offset, k)
-                * MATRIX(mat_a, col_size, offset + k, col));
+        sum += (MATRIX(householder_mat, vec_size, row - offset, k) *
+                MATRIX(mat_a, col_size, offset + k, col));
       }
       MATRIX(mat_temp, col_size, row, col) = sum;
     }
@@ -115,8 +103,8 @@ void MultiplyHouseholderMatrixFromLeft(
   }
 }
 
-void ComputeHouseholderBidiagonalization(
-    double* mat_a, const int row_size, const int col_size) {
+void ComputeHouseholderBidiagonalization(double* mat_a, const int row_size,
+                                         const int col_size) {
   // TODO: support row_size < col_size
   assert(row_size >= col_size);
   double vec_col[row_size];
@@ -127,10 +115,12 @@ void ComputeHouseholderBidiagonalization(
     const int vec_col_size = row_size - j;
 
     GetColumnVector(mat_a, vec_col, j, j, vec_col_size, row_size, col_size);
-    ComputeHouseholderVector(vec_col, vec_col_size, householder_vec, &householder_coeff);
+    ComputeHouseholderVector(vec_col, vec_col_size, householder_vec,
+                             &householder_coeff);
 
-    MultiplyHouseholderMatrixFromLeft(
-        mat_a, row_size, col_size, householder_vec, householder_coeff, vec_col_size);
+    MultiplyHouseholderMatrixFromLeft(mat_a, row_size, col_size,
+                                      householder_vec, householder_coeff,
+                                      vec_col_size);
     // assign householder vector to A
     for (int row = j + 1; row < row_size; ++row) {
       MATRIX(mat_a, col_size, row, j) = householder_vec[row - j];
@@ -139,7 +129,8 @@ void ComputeHouseholderBidiagonalization(
     if (j < col_size - 2) {
       const int vec_row_size = col_size - (j + 1);
       GetRowVector(mat_a, vec_row, j, j + 1, vec_row_size, row_size, col_size);
-      ComputeHouseholderVector(vec_row, vec_row_size, householder_vec, &householder_coeff);
+      ComputeHouseholderVector(vec_row, vec_row_size, householder_vec,
+                               &householder_coeff);
 
       //   (I - beta vv^{T})
       std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
@@ -152,16 +143,17 @@ void ComputeHouseholderBidiagonalization(
         for (int col = 0; col < vec_row_size; ++col) {
           double sum = 0.0;
           for (int k = 0; k < vec_row_size; ++k) {
-            sum += (MATRIX(mat_a, col_size, row + j, (col_size - vec_row_size) + k)
-                    * MATRIX(householder_mat, vec_row_size, k, col));
+            sum += (MATRIX(mat_a, col_size, row + j,
+                           (col_size - vec_row_size) + k) *
+                    MATRIX(householder_mat, vec_row_size, k, col));
           }
           MATRIX(mat_temp, vec_row_size, row, col) = sum;
         }
       }
       for (int row = 0; row < row_size - j; ++row) {
         for (int col = 0; col < vec_row_size; ++col) {
-          MATRIX(mat_a, col_size + j, row + j, col + col_size - vec_row_size) 
-            = MATRIX(mat_temp, vec_row_size, row, col);
+          MATRIX(mat_a, col_size + j, row + j, col + col_size - vec_row_size) =
+              MATRIX(mat_temp, vec_row_size, row, col);
         }
       }
 
@@ -174,8 +166,7 @@ void ComputeHouseholderBidiagonalization(
 }
 
 std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToB(
-    const double* mat_a, const int row_size, const int col_size)
-{
+    const double* mat_a, const int row_size, const int col_size) {
   // TODO(i05nagai): Support row_size < col_size
   assert(row_size >= col_size);
   std::unique_ptr<double[]> data(new double[row_size * col_size]);
@@ -184,7 +175,8 @@ std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToB(
   for (int col = 0; col < col_size; ++col) {
     MATRIX(data, col_size, col, col) = MATRIX(mat_a, col_size, col, col);
     if (col < col_size - 1) {
-      MATRIX(data, col_size, col, col + 1) = MATRIX(mat_a, col_size, col, col + 1);
+      MATRIX(data, col_size, col, col + 1) =
+          MATRIX(mat_a, col_size, col, col + 1);
     }
   }
   return data;
@@ -192,4 +184,3 @@ std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToB(
 
 }  // namespace linear_algebra
 }  // namespace recipe
-

--- a/recipe/linear_algebra/householder.cc
+++ b/recipe/linear_algebra/householder.cc
@@ -1,0 +1,86 @@
+#include "recipe/linear_algebra/householder.h"
+#include <cassert>
+#include <cmath>
+#include <numeric>
+#include <stdexcept>
+#include "recipe/linear_algebra/operator_binary.h"
+#include "recipe/linear_algebra/base.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+void ComputeHouseholderVector(
+    const double* vec_x,
+    const int size_vec,
+    double* householder_vec,
+    double* householder_coeff)
+{
+  assert(size_vec > 0);
+  const double sum0 = InnerProduct(vec_x + 1, vec_x + 1, size_vec - 1);
+  for (int i = 0; i < size_vec; ++i) {
+    householder_vec[i] = vec_x[i];
+  }
+
+  if (sum0 == 0.0) {
+    // x is in span(e1)
+    *householder_coeff = 0.0;
+  } else {
+    const double norm = std::sqrt(vec_x[0] * vec_x[0] + sum0);
+    // calculate v1 = x1 - norm(x)
+    if (vec_x[0] <= 0.0) {
+      householder_vec[0] = vec_x[0] - norm;
+    } else {
+      householder_vec[0] = - sum0 / (vec_x[0] + norm);
+    }
+    // update coeff
+    *householder_coeff = 2.0 * householder_vec[0] * householder_vec[0]
+      / (sum0 + householder_vec[0] * householder_vec[0]);
+    for (int i = size_vec - 1; i >= 0; --i) {
+      householder_vec[i] /= householder_vec[0];
+    }
+  }
+}
+
+std::unique_ptr<double[]> ComputeHouseholderMatrix(
+    const double* householder_vec,
+    const double householder_coeff,
+    const int size)
+{
+  std::unique_ptr<double[]> mat_data(new double[size * size]);
+  for (int row = 0; row < size; ++row) {
+    for (int col = 0; col < size; ++col) {
+      if (row == col) {
+        MATRIX(mat_data, size, row, col) 
+          = 1.0 - householder_coeff * householder_vec[row] * householder_vec[col];
+      } else {
+        MATRIX(mat_data, size, row, col) 
+          = - householder_coeff * householder_vec[row] * householder_vec[col];
+      }
+    }
+  }
+  return mat_data;
+}
+
+void ComputeHouseholderVector(
+    const Vector vec_x,
+    Vector* householder_vec,
+    double* householder_coeff)
+{
+  const int size = vec_x.Size();
+  ComputeHouseholderVector(
+      vec_x.Get(), size, householder_vec->Get(), householder_coeff);
+}
+
+Matrix ComputeHouseholderMatrix(
+    const Vector householder_vec,
+    const double householder_coeff)
+{
+  const int size = householder_vec.Size();
+  std::unique_ptr<double[]> data = ComputeHouseholderMatrix(
+      householder_vec.Get(), householder_coeff, size);
+  return Matrix(size, size, std::move(data));
+}
+
+}  // namespace linear_algebra
+}  // namespace recipe
+

--- a/recipe/linear_algebra/householder.cc
+++ b/recipe/linear_algebra/householder.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <numeric>
 #include <stdexcept>
+#include <algorithm>
 #include "recipe/linear_algebra/operator_binary.h"
 #include "recipe/linear_algebra/base.h"
 
@@ -79,6 +80,114 @@ Matrix ComputeHouseholderMatrix(
   std::unique_ptr<double[]> data = ComputeHouseholderMatrix(
       householder_vec.Get(), householder_coeff, size);
   return Matrix(size, size, std::move(data));
+}
+
+void MultiplyHouseholderMatrixFromLeft(
+    double* mat_a,
+    const int row_size,
+    const int col_size,
+    const double* householder_vec,
+    const double householder_coeff,
+    const int vec_size)
+{
+  // TODO: Support row_size < col_size
+  assert(row_size >= col_size);
+  std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
+      householder_vec, householder_coeff, vec_size);
+  const int offset = row_size - vec_size;
+  // (I - beta vv^{T})
+  // A[row_size-vec_size:(row_size-1), col_size-vec_size:(col_size-1)]
+  double mat_temp[row_size * col_size];
+  for (int row = offset; row < row_size; ++row) {
+    for (int col = offset; col< col_size; ++col) {
+      double sum = 0.0;
+      for (int k = 0; k < vec_size; ++k) {
+        sum += (MATRIX(householder_mat, vec_size, row - offset, k)
+                * MATRIX(mat_a, col_size, offset + k, col));
+      }
+      MATRIX(mat_temp, col_size, row, col) = sum;
+    }
+  }
+  for (int row = offset; row < row_size; ++row) {
+    for (int col = offset; col < col_size; ++col) {
+      MATRIX(mat_a, col_size, row, col) = MATRIX(mat_temp, col_size, row, col);
+    }
+  }
+}
+
+void ComputeHouseholderBidiagonalization(
+    double* mat_a, const int row_size, const int col_size) {
+  // TODO: support row_size < col_size
+  assert(row_size >= col_size);
+  double vec_col[row_size];
+  double vec_row[col_size];
+  double householder_vec[row_size];
+  double householder_coeff;
+  for (int j = 0; j < col_size; ++j) {
+    const int vec_col_size = row_size - j;
+
+    GetColumnVector(mat_a, vec_col, j, j, vec_col_size, row_size, col_size);
+    ComputeHouseholderVector(vec_col, vec_col_size, householder_vec, &householder_coeff);
+
+    MultiplyHouseholderMatrixFromLeft(
+        mat_a, row_size, col_size, householder_vec, householder_coeff, vec_col_size);
+    // assign householder vector to A
+    for (int row = j + 1; row < row_size; ++row) {
+      MATRIX(mat_a, col_size, row, j) = householder_vec[row - j];
+    }
+
+    if (j < col_size - 2) {
+      const int vec_row_size = col_size - (j + 1);
+      GetRowVector(mat_a, vec_row, j, j + 1, vec_row_size, row_size, col_size);
+      ComputeHouseholderVector(vec_row, vec_row_size, householder_vec, &householder_coeff);
+
+      //   (I - beta vv^{T})
+      std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
+          householder_vec, householder_coeff, vec_row_size);
+
+      // A[row_size-vec_size:(row_size-1), col_size-vec_size:(col_size-1)]
+      // * (I - beta vv^{T})
+      double mat_temp[row_size * vec_row_size];
+      for (int row = 0; row < row_size - j; ++row) {
+        for (int col = 0; col < vec_row_size; ++col) {
+          double sum = 0.0;
+          for (int k = 0; k < vec_row_size; ++k) {
+            sum += (MATRIX(mat_a, col_size, row + j, (col_size - vec_row_size) + k)
+                    * MATRIX(householder_mat, vec_row_size, k, col));
+          }
+          MATRIX(mat_temp, vec_row_size, row, col) = sum;
+        }
+      }
+      for (int row = 0; row < row_size - j; ++row) {
+        for (int col = 0; col < vec_row_size; ++col) {
+          MATRIX(mat_a, col_size + j, row + j, col + col_size - vec_row_size) 
+            = MATRIX(mat_temp, vec_row_size, row, col);
+        }
+      }
+
+      // assign householder vector to A
+      for (int col = j + 2; col < col_size; ++col) {
+        MATRIX(mat_a, col_size, j, col) = householder_vec[col - (j + 1)];
+      }
+    }
+  }
+}
+
+std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToB(
+    const double* mat_a, const int row_size, const int col_size)
+{
+  // TODO(i05nagai): Support row_size < col_size
+  assert(row_size >= col_size);
+  std::unique_ptr<double[]> data(new double[row_size * col_size]);
+  std::fill(data.get(), data.get() + row_size * col_size, 0.0);
+  // because row_size >= col_size
+  for (int col = 0; col < col_size; ++col) {
+    MATRIX(data, col_size, col, col) = MATRIX(mat_a, col_size, col, col);
+    if (col < col_size - 1) {
+      MATRIX(data, col_size, col, col + 1) = MATRIX(mat_a, col_size, col, col + 1);
+    }
+  }
+  return data;
 }
 
 }  // namespace linear_algebra

--- a/recipe/linear_algebra/householder.h
+++ b/recipe/linear_algebra/householder.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <vector>
+#include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/vector.h"
+#include "recipe/linear_algebra/util.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+/// @brief Compute Householder Vector of vec_x.
+/// Calcualte $v$ and $\\beta$ which satisfy
+///
+/// $$
+///   (I - \\beta vv^{\mathrm{T}})x
+///   =
+///   \\|x\\|_{2} e_{1}
+/// $$
+/// 
+/// where $(e_{i})$ is a standard basis of euclid space
+/// and $v = (1, v^{2}, \\ldots, v^{2})$.
+///
+/// @param vec_x vector $x$.
+/// @param size_vec size of vector $x$ and $v$.
+/// @param householder_vec Householder vector $v$.
+/// @param householder_coeff Householder coefficient $\\beta$.
+/// 
+void ComputeHouseholderVector(
+    const double* vec_x,
+    const int size_vec,
+    double* householder_vec,
+    double* householder_coeff);
+
+/// @brief Compute Householder matrix
+///
+/// $$
+///   (I - \\beta vv^{\\mathrm{T}})
+/// $$
+///
+/// where $\\beta := 2 / \\|v\\|_{2}^{2}$ and $v$ is a householder vectror.
+///
+/// @param householder_vec Householder vector $v$
+/// @param householder_coeff coefficient of Householder transformation $\\beta$.
+/// @param size the size of vector $v$.
+///
+/// @return array of matrix $M$ whose values are stored in row majored order.
+///
+std::unique_ptr<double[]> ComputeHouseholderMatrix(
+    const double* householder_vec,
+    const double householder_coeff,
+    const int size);
+
+void ComputeHouseholderVector(
+    const Vector vec_x,
+    Vector* householder_vec,
+    double* householder_coeff);
+
+Matrix ComputeHouseholderMatrix(
+    const Vector householder_vec,
+    const double householder_coeff);
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/householder.h
+++ b/recipe/linear_algebra/householder.h
@@ -57,5 +57,49 @@ void ComputeHouseholderVector(
 Matrix ComputeHouseholderMatrix(
     const Vector householder_vec,
     const double householder_coeff);
+
+/// @brief 
+///
+///
+/// @param mat_a
+/// @param row_size
+/// @param col_size
+/// @param householder_vec
+/// @param householder_coeff
+/// @param vec_size
+/// 
+void MultiplyHouseholderMatrixFromLeft(
+    double* mat_a,
+    const int row_size,
+    const int col_size,
+    const double* householder_vec,
+    const double householder_coeff,
+    const int vec_size);
+
+/// @brief 
+///
+/// @param mat_a
+/// @param row_size
+/// @param col_size
+/// 
+void ComputeHouseholderBidiagonalization(
+    double* mat_a, const int row_size, const int col_size);
+
+// TODO(i05naga): not implemented yet
+std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToU(
+    const double* mat_a, const int row_size, const int col_size);
+// TODO(i05naga): not implemented yet
+std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToV(
+    const double* mat_a, const int row_size, const int col_size);
+/// @brief Extract the bidiagonal matrix $B$ from the result of 
+/// `ComputeHouseholderBidiagonalization`.
+///
+/// @param mat_a
+/// @param row_size
+/// @param col_size
+/// 
+std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToB(
+    const double* mat_a, const int row_size, const int col_size);
+
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/householder.h
+++ b/recipe/linear_algebra/householder.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <vector>
 #include "recipe/linear_algebra/matrix.h"
-#include "recipe/linear_algebra/vector.h"
 #include "recipe/linear_algebra/util.h"
+#include "recipe/linear_algebra/vector.h"
 
 namespace recipe {
 namespace linear_algebra {
@@ -15,7 +15,7 @@ namespace linear_algebra {
 ///   =
 ///   \\|x\\|_{2} e_{1}
 /// $$
-/// 
+///
 /// where $(e_{i})$ is a standard basis of euclid space
 /// and $v = (1, v^{2}, \\ldots, v^{2})$.
 ///
@@ -23,12 +23,10 @@ namespace linear_algebra {
 /// @param size_vec size of vector $x$ and $v$.
 /// @param householder_vec Householder vector $v$.
 /// @param householder_coeff Householder coefficient $\\beta$.
-/// 
-void ComputeHouseholderVector(
-    const double* vec_x,
-    const int size_vec,
-    double* householder_vec,
-    double* householder_coeff);
+///
+void ComputeHouseholderVector(const double* vec_x, const int size_vec,
+                              double* householder_vec,
+                              double* householder_coeff);
 
 /// @brief Compute Householder matrix
 ///
@@ -45,20 +43,16 @@ void ComputeHouseholderVector(
 /// @return array of matrix $M$ whose values are stored in row majored order.
 ///
 std::unique_ptr<double[]> ComputeHouseholderMatrix(
-    const double* householder_vec,
-    const double householder_coeff,
+    const double* householder_vec, const double householder_coeff,
     const int size);
 
-void ComputeHouseholderVector(
-    const Vector vec_x,
-    Vector* householder_vec,
-    double* householder_coeff);
+void ComputeHouseholderVector(const Vector vec_x, Vector* householder_vec,
+                              double* householder_coeff);
 
-Matrix ComputeHouseholderMatrix(
-    const Vector householder_vec,
-    const double householder_coeff);
+Matrix ComputeHouseholderMatrix(const Vector householder_vec,
+                                const double householder_coeff);
 
-/// @brief 
+/// @brief
 ///
 ///
 /// @param mat_a
@@ -67,23 +61,21 @@ Matrix ComputeHouseholderMatrix(
 /// @param householder_vec
 /// @param householder_coeff
 /// @param vec_size
-/// 
-void MultiplyHouseholderMatrixFromLeft(
-    double* mat_a,
-    const int row_size,
-    const int col_size,
-    const double* householder_vec,
-    const double householder_coeff,
-    const int vec_size);
+///
+void MultiplyHouseholderMatrixFromLeft(double* mat_a, const int row_size,
+                                       const int col_size,
+                                       const double* householder_vec,
+                                       const double householder_coeff,
+                                       const int vec_size);
 
-/// @brief 
+/// @brief
 ///
 /// @param mat_a
 /// @param row_size
 /// @param col_size
-/// 
-void ComputeHouseholderBidiagonalization(
-    double* mat_a, const int row_size, const int col_size);
+///
+void ComputeHouseholderBidiagonalization(double* mat_a, const int row_size,
+                                         const int col_size);
 
 // TODO(i05naga): not implemented yet
 std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToU(
@@ -91,13 +83,13 @@ std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToU(
 // TODO(i05naga): not implemented yet
 std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToV(
     const double* mat_a, const int row_size, const int col_size);
-/// @brief Extract the bidiagonal matrix $B$ from the result of 
+/// @brief Extract the bidiagonal matrix $B$ from the result of
 /// `ComputeHouseholderBidiagonalization`.
 ///
 /// @param mat_a
 /// @param row_size
 /// @param col_size
-/// 
+///
 std::unique_ptr<double[]> ConvertHouseholderBidiagonalizationToB(
     const double* mat_a, const int row_size, const int col_size);
 

--- a/recipe/linear_algebra/householder_test.cc
+++ b/recipe/linear_algebra/householder_test.cc
@@ -1,9 +1,9 @@
 #include "recipe/linear_algebra/householder.h"
 #include <gtest/gtest.h>
-#include "recipe/linear_algebra/test_util/test_data.h"
-#include "recipe/linear_algebra/test_util/gtest_assertion.h"
-#include "recipe/linear_algebra/operator_unary.h"
 #include "recipe/linear_algebra/operator_binary.h"
+#include "recipe/linear_algebra/operator_unary.h"
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include "recipe/linear_algebra/test_util/test_data.h"
 #include "recipe/test_util/test_util.h"
 
 namespace recipe {
@@ -15,15 +15,14 @@ namespace linear_algebra {
 TEST(ComputeHouseholderVectorTest, Size1) {
   const int size = 1;
   const double vec_x[] = {
-    3.0,
+      3.0,
   };
   std::unique_ptr<double[]> actual_vec(new double[size]);
   double actual_coeff = 0.0;
-  ComputeHouseholderVector(
-      vec_x, size, actual_vec.get(), &actual_coeff);
+  ComputeHouseholderVector(vec_x, size, actual_vec.get(), &actual_coeff);
   // expect
   double expect_vec[size] = {
-    3.0,
+      3.0,
   };
   double expect_coeff = 0.0;
   // compare
@@ -34,21 +33,23 @@ TEST(ComputeHouseholderVectorTest, Size1) {
 TEST(ComputeHouseholderVectorTest, Example0) {
   const int size = 4;
   const double vec_x[] = {
-    3.0, 1.0, 5.0, 1.0,
+      3.0,
+      1.0,
+      5.0,
+      1.0,
   };
   std::unique_ptr<double[]> actual_vec(new double[size]);
   double actual_coeff = 0.0;
-  ComputeHouseholderVector(
-      vec_x, size, actual_vec.get(), &actual_coeff);
+  ComputeHouseholderVector(vec_x, size, actual_vec.get(), &actual_coeff);
   // expect
   const double v1 = vec_x[0] - NormEuclid(vec_x, size);
   double expect_vec[size] = {
-    // clang-format off
+      // clang-format off
     1.0,
     1.0 / v1,
     5.0 / v1,
     1.0 / v1,
-    // clang-format on
+      // clang-format on
   };
   const double expect_coeff = 2.0 / InnerProduct(expect_vec, expect_vec, size);
   // compare
@@ -59,15 +60,18 @@ TEST(ComputeHouseholderVectorTest, Example0) {
 TEST(ComputeHouseholderVectorTest, NormIsDominatedByFirstElement) {
   const int size = 3;
   const double vec_x[] = {
-    3.0, 0.0, 0.0,
+      3.0,
+      0.0,
+      0.0,
   };
   std::unique_ptr<double[]> actual_vec(new double[size]);
   double actual_coeff = 0.0;
-  ComputeHouseholderVector(
-      vec_x, size, actual_vec.get(), &actual_coeff);
+  ComputeHouseholderVector(vec_x, size, actual_vec.get(), &actual_coeff);
   // expect
   double expect_vec[size] = {
-    3.0, 0.0, 0.0,
+      3.0,
+      0.0,
+      0.0,
   };
   const double expect_coeff = 0.0;
   // compare
@@ -84,12 +88,14 @@ TEST(ComputeHouseholderMatrixTest, Example0) {
   // I - beta * v * v^{T}
   Matrix actual = ComputeHouseholderMatrix(householder_vec, householder_coeff);
   // expect
-  const Matrix expect = MakeMatrix({
-    {0.07761499999999999, 0.31046003284, 0.54330505747, 0.7761510044850001},
-    {0.31046003284, 0.8955041203065814, -0.1828677894634825, -0.2612400096935792},
-    {0.54330505747, -0.1828677894634825, 0.6799813684389056, -0.4571700169637637},
-    {0.7761510044850001, -0.2612400096935792, -0.4571700169637637, 0.3468991996150474}
-  });
+  const Matrix expect = MakeMatrix(
+      {{0.07761499999999999, 0.31046003284, 0.54330505747, 0.7761510044850001},
+       {0.31046003284, 0.8955041203065814, -0.1828677894634825,
+        -0.2612400096935792},
+       {0.54330505747, -0.1828677894634825, 0.6799813684389056,
+        -0.4571700169637637},
+       {0.7761510044850001, -0.2612400096935792, -0.4571700169637637,
+        0.3468991996150474}});
   // compare
   EXPECT_MATRIX_ELEMENT_NEAR(expect, actual, 1e-15);
 }
@@ -97,17 +103,21 @@ TEST(ComputeHouseholderMatrixTest, Example0) {
 // (I - beta * v * v^{T}) x = norm(x) e1
 TEST(ComputeHouseholderMatrixTest, EnsureRelation0) {
   const Vector vec_x = TestData::GetRandomVector(4);
-  Vector householder_vec (vec_x.Size());
+  Vector householder_vec(vec_x.Size());
   double householder_coeff = 0.0;
   ComputeHouseholderVector(vec_x, &householder_vec, &householder_coeff);
 
   // I - beta * v * v^{T}
-  Matrix householder_mat = ComputeHouseholderMatrix(householder_vec, householder_coeff);
+  Matrix householder_mat =
+      ComputeHouseholderMatrix(householder_vec, householder_coeff);
   // (I - beta * v * v^{T}) x
   Vector actual = Multiply(householder_mat, vec_x);
   // expect
   const Vector expect = MakeVector({
-    NormEuclid(vec_x), 0.0, 0.0, 0.0,
+      NormEuclid(vec_x),
+      0.0,
+      0.0,
+      0.0,
   });
   // compare
   EXPECT_VECTOR_ELEMENT_NEAR(expect, actual, 1e-15);
@@ -118,35 +128,34 @@ TEST(ComputeHouseholderMatrixTest, EnsureRelation0) {
 //
 TEST(MultiplyHouseholderMatrixFromLeftTest, EnsureRelation0) {
   Matrix mat_a = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {1, 2, 3},
     {4, 5, 6},
     {7, 8, 9},
     {10, 11, 12},
-    // clang-format on
+      // clang-format on
   });
   Vector vec_col = MakeVector({
-    1.0, 4.0, 7.0, 10.0,
+      1.0,
+      4.0,
+      7.0,
+      10.0,
   });
   Vector householder_vec(4);
   double householder_coeff = 0.0;
   ComputeHouseholderVector(vec_col, &householder_vec, &householder_coeff);
-  MultiplyHouseholderMatrixFromLeft(
-    mat_a.Get(),
-    mat_a.NumRow(),
-    mat_a.NumCol(),
-    householder_vec.Get(),
-    householder_coeff,
-    vec_col.Size());
+  MultiplyHouseholderMatrixFromLeft(mat_a.Get(), mat_a.NumRow(), mat_a.NumCol(),
+                                    householder_vec.Get(), householder_coeff,
+                                    vec_col.Size());
 
   // expect
   const Matrix expect = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {12.884098726725128, 14.591629883279058, 16.299161039832992},
     {0.0, 0.76185618351930184, 1.5237123670386037},
     {0.0, 0.58324832115877534, 1.1664966423175533},
     {0.0, 0.40464045879825239, 0.80928091759650655},
-    // clang-format on
+      // clang-format on
   });
   EXPECT_MATRIX_ELEMENT_NEAR(expect, mat_a, 1e-8);
 }
@@ -158,23 +167,24 @@ TEST(MultiplyHouseholderMatrixFromLeftTest, EnsureRelation0) {
 // (I - beta * v * v^{T}) x
 TEST(ComputeHouseholderBidiagonalizationTest, Example0) {
   Matrix mat_a = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {1, 2, 3},
     {4, 5, 6},
     {7, 8, 9},
     {10, 11, 12},
-    // clang-format on
+      // clang-format on
   });
-  ComputeHouseholderBidiagonalization(mat_a.Get(), mat_a.NumRow(), mat_a.NumCol());
+  ComputeHouseholderBidiagonalization(mat_a.Get(), mat_a.NumRow(),
+                                      mat_a.NumCol());
 
   // expect
   const Matrix expect = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {12.884098726725128, 21.876432827428971, -2.237419620653168},
     {-0.33658421155697277, 2.246235240294709, -0.61328133205414748},
     {-0.58902237022470239, -2.087062084628617, 0.0},
     {-0.84146052889243195, -1.4479420322834726, -3.1623721622453869},
-    // clang-format on
+      // clang-format on
   });
   // compare
   EXPECT_MATRIX_ELEMENT_NEAR(expect, mat_a, 1e-14);
@@ -182,16 +192,17 @@ TEST(ComputeHouseholderBidiagonalizationTest, Example0) {
 
 TEST(ComputeHouseholderBidiagonalizationTest, AlreadyBidiagonal) {
   Matrix mat_a = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {1, 1, 0, 0},
     {0, 2, 1, 0},
     {0, 0, 3, 1},
     {0, 0, 0, 4},
-    // clang-format on
+      // clang-format on
   });
   // FIXME
   /*
-  ComputeHouseholderBidiagonalization(mat_a.Get(), mat_a.NumRow(), mat_a.NumCol());
+  ComputeHouseholderBidiagonalization(mat_a.Get(), mat_a.NumRow(),
+  mat_a.NumCol());
 
   // expect
   const Matrix expect = MakeMatrix({
@@ -206,25 +217,26 @@ TEST(ComputeHouseholderBidiagonalizationTest, AlreadyBidiagonal) {
 // (I - beta * v * v^{T}) x
 TEST(ConvertHouseholderBidiagonalizationToBTest, Example0) {
   Matrix mat_a = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {1, 2, 3},
     {4, 5, 6},
     {7, 8, 9},
     {10, 11, 12},
-    // clang-format on
+      // clang-format on
   });
-  ComputeHouseholderBidiagonalization(mat_a.Get(), mat_a.NumRow(), mat_a.NumCol());
+  ComputeHouseholderBidiagonalization(mat_a.Get(), mat_a.NumRow(),
+                                      mat_a.NumCol());
   std::unique_ptr<double[]> actual = ConvertHouseholderBidiagonalizationToB(
       mat_a.Get(), mat_a.NumRow(), mat_a.NumCol());
 
   // expect
   const Matrix expect = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {12.884098726725128, 21.876432827428971, 0.0},
     {0.0, 2.246235240294709, -0.61328133205414748},
     {0.0, 0.0, 0.0},
     {0.0, 0.0, 0.0},
-    // clang-format on
+      // clang-format on
   });
   // compare
   const int size = mat_a.NumRow() * mat_a.NumCol();

--- a/recipe/linear_algebra/householder_test.cc
+++ b/recipe/linear_algebra/householder_test.cc
@@ -1,0 +1,102 @@
+#include "recipe/linear_algebra/householder.h"
+#include <gtest/gtest.h>
+#include "recipe/linear_algebra/test_util/test_data.h"
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include "recipe/linear_algebra/operator_unary.h"
+#include "recipe/linear_algebra/operator_binary.h"
+#include "recipe/test_util/test_util.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+//
+// ComputeHouseholderVector
+//
+TEST(ComputeHouseholderVectorTest, Size1) {
+  const int size = 1;
+  const double vec_x[] = {
+    3.0,
+  };
+  std::unique_ptr<double[]> actual_vec(new double[size]);
+  double actual_coeff = 0.0;
+  ComputeHouseholderVector(
+      vec_x, size, actual_vec.get(), &actual_coeff);
+  // expect
+  double expect_vec[size] = {
+    3.0,
+  };
+  double expect_coeff = 0.0;
+  // compare
+  EXPECT_ARRAY_ELEMENT_EQ(expect_vec, actual_vec, size);
+  EXPECT_DOUBLE_EQ(expect_coeff, actual_coeff);
+}
+
+TEST(ComputeHouseholderVectorTest, Example0) {
+  const int size = 4;
+  const double vec_x[] = {
+    3.0, 1.0, 5.0, 1.0,
+  };
+  std::unique_ptr<double[]> actual_vec(new double[size]);
+  double actual_coeff = 0.0;
+  ComputeHouseholderVector(
+      vec_x, size, actual_vec.get(), &actual_coeff);
+  // expect
+  const double v1 = vec_x[0] - NormEuclid(vec_x, size);
+  double expect_vec[size] = {
+    // clang-format off
+    1.0,
+    1.0 / v1,
+    5.0 / v1,
+    1.0 / v1,
+    // clang-format on
+  };
+  const double expect_coeff = 2.0 / InnerProduct(expect_vec, expect_vec, size);
+  // compare
+  EXPECT_ARRAY_ELEMENT_EQ(expect_vec, actual_vec, size);
+  EXPECT_DOUBLE_EQ(expect_coeff, actual_coeff);
+}
+
+TEST(ComputeHouseholderVectorTest, NormIsDominatedByFirstElement) {
+  const int size = 3;
+  const double vec_x[] = {
+    3.0, 0.0, 0.0,
+  };
+  std::unique_ptr<double[]> actual_vec(new double[size]);
+  double actual_coeff = 0.0;
+  ComputeHouseholderVector(
+      vec_x, size, actual_vec.get(), &actual_coeff);
+  // expect
+  double expect_vec[size] = {
+    3.0, 0.0, 0.0,
+  };
+  const double expect_coeff = 0.0;
+  // compare
+  EXPECT_ARRAY_ELEMENT_EQ(expect_vec, actual_vec, size);
+  EXPECT_DOUBLE_EQ(expect_coeff, actual_coeff);
+}
+
+//
+// ComputeHouseholderMatrix
+//
+
+// (I - beta * v * v^{T}) x = norm(x) e1
+TEST(ComputeHouseholderMatrixTest, EnsureRelation0) {
+  const Vector vec_x = TestData::GetRandomVector(4);
+  Vector householder_vec (vec_x.Size());
+  double householder_coeff = 0.0;
+  ComputeHouseholderVector(vec_x, &householder_vec, &householder_coeff);
+
+  // I - beta * v * v^{T}
+  Matrix householder_mat = ComputeHouseholderMatrix(householder_vec, householder_coeff);
+  // (I - beta * v * v^{T}) x
+  Vector actual = Multiply(householder_mat, vec_x);
+  // expect
+  const Vector expect = MakeVector({
+    NormEuclid(vec_x), 0.0, 0.0, 0.0,
+  });
+  // compare
+  EXPECT_VECTOR_ELEMENT_NEAR(expect, actual, 1e-15);
+}
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/householder_test.cc
+++ b/recipe/linear_algebra/householder_test.cc
@@ -89,13 +89,12 @@ TEST(ComputeHouseholderMatrixTest, Example0) {
   Matrix actual = ComputeHouseholderMatrix(householder_vec, householder_coeff);
   // expect
   const Matrix expect = MakeMatrix(
+      // clang-format off
       {{0.07761499999999999, 0.31046003284, 0.54330505747, 0.7761510044850001},
-       {0.31046003284, 0.8955041203065814, -0.1828677894634825,
-        -0.2612400096935792},
-       {0.54330505747, -0.1828677894634825, 0.6799813684389056,
-        -0.4571700169637637},
-       {0.7761510044850001, -0.2612400096935792, -0.4571700169637637,
-        0.3468991996150474}});
+       {0.31046003284, 0.8955041203065814, -0.1828677894634825, -0.2612400096935792},
+       {0.54330505747, -0.1828677894634825, 0.6799813684389056, -0.4571700169637637},
+       {0.7761510044850001, -0.2612400096935792, -0.4571700169637637, 0.3468991996150474}});
+  // clang-format on
   // compare
   EXPECT_MATRIX_ELEMENT_NEAR(expect, actual, 1e-15);
 }
@@ -199,7 +198,8 @@ TEST(ComputeHouseholderBidiagonalizationTest, AlreadyBidiagonal) {
     {0, 0, 0, 4},
       // clang-format on
   });
-  // FIXME
+  // FIXME: HouseholderBidiagonalization should work
+  // if a matrix is already bidiagonal.
   /*
   ComputeHouseholderBidiagonalization(mat_a.Get(), mat_a.NumRow(),
   mat_a.NumCol());

--- a/recipe/linear_algebra/matrix.cc
+++ b/recipe/linear_algebra/matrix.cc
@@ -6,6 +6,9 @@
 namespace recipe {
 namespace linear_algebra {
 
+Matrix::Matrix()
+    : num_row_(0), num_col_(0), data_(nullptr) {}
+
 Matrix::Matrix(const int num_row, const int num_col,
                std::unique_ptr<double[]> data)
     : num_row_(num_row), num_col_(num_col), data_(std::move(data)) {}
@@ -144,8 +147,28 @@ void GetColumnVector(
   assert(0 <= row_offset && row_offset < row_size);
   assert(0 <= col_index && col_index < col_size);
   assert(vec_size <= (row_size - row_offset));
-  for (int i = 0; i < vec_size; ++i) {
-    vec[i] = mat[(row_offset + i) * col_size + col_index];
+  for (int row = 0; row < vec_size; ++row) {
+    vec[row] = mat[(row_offset + row) * col_size + col_index];
+  }
+}
+
+void GetRowVector(
+    const double* mat,
+    double* vec,
+    const int row_index,
+    const int col_offset,
+    const int vec_size,
+    const size_t row_size,
+    const size_t col_size)
+{
+  // col_size(mat) - col_offset >= vec_size
+  // row_index in [0, row_size(mat))
+  // col_offset in [0, col_size(mat))
+  assert(0 <= col_offset && col_offset < col_size);
+  assert(0 <= row_index && row_index < row_size);
+  assert(vec_size <= (col_size - col_offset));
+  for (int col = 0; col < vec_size; ++col) {
+    vec[col] = mat[row_index * col_size + col + col_offset];
   }
 }
 

--- a/recipe/linear_algebra/matrix.cc
+++ b/recipe/linear_algebra/matrix.cc
@@ -23,6 +23,23 @@ Matrix::Matrix(const Matrix& other)
             data_.get());
 }
 
+Matrix Matrix::Slice(
+    const int row_from, const int row_to, const int col_from, const int col_to) const
+{
+  assert(0 <= row_from && row_from <= row_to && row_to < num_row_);
+  assert(0 <= col_from && col_from <= col_to && col_to < num_col_);
+
+  const int row_size = (row_to - row_from + 1);
+  const int col_size = (col_to - col_from + 1);
+  Matrix sliced(row_size, col_size);
+  for (int row = row_from; row <= row_to; ++row) {
+    for (int col = col_from; col <= col_to; ++col) {
+      sliced(row - row_from, col - col_from) = this->operator()(row, col);
+    }
+  }
+  return sliced;
+}
+
 double Matrix::operator()(const int row, const int col) const {
   assert(0 <= row && row < num_row_ && 0 <= col && col < num_col_);
   return data_[row * num_col_ + col];
@@ -50,6 +67,43 @@ bool Matrix::operator==(const Matrix& other) const {
                     other.data_.get());
 }
 
+//
+// Free functions
+//
+
+void AssignMatrix(
+    Matrix* assignee,
+    const Matrix& assigner,
+    const int row_offset,
+    const int col_offset)
+{
+  assert(0 <= row_offset && row_offset < assignee->NumRow());
+  assert(0 <= col_offset && col_offset < assignee->NumCol());
+
+  assert(assigner.NumRow() + row_offset <= assignee->NumRow());
+  assert(assigner.NumCol() + col_offset <= assignee->NumCol());
+  for (int row = 0; row < assigner.NumRow(); ++row) {
+    for (int col = 0; col < assigner.NumCol(); ++col) {
+      (*assignee)(row + row_offset, col + col_offset) = assigner(row, col);
+    }
+  }
+}
+
+void AssignVector(
+    Matrix* assignee,
+    const Vector& assigner,
+    const int row_offset,
+    const int col_offset)
+{
+  assert(0 <= row_offset && row_offset < assignee->NumRow());
+  assert(0 <= col_offset && col_offset < assignee->NumCol());
+
+  assert(assigner.Size() + row_offset <= assignee->NumCol());
+  for (int row = 0; row < assigner.Size(); ++row) {
+    (*assignee)(row + row_offset, col_offset) = assigner(row);
+  }
+}
+
 Matrix MakeMatrix(std::initializer_list<std::initializer_list<double>> list) {
   const int size_row = list.size();
   if (size_row == 0) {
@@ -73,6 +127,26 @@ Matrix MakeIdentityMatrix(const int size) {
     data[i * size + i] = 1.0;
   }
   return Matrix(size, size, std::move(data));
+}
+
+void GetColumnVector(
+    const double* mat,
+    double* vec,
+    const int col_index,
+    const int row_offset,
+    const int vec_size,
+    const size_t row_size,
+    const size_t col_size)
+{
+  // row_size(mat) - row_offset >= vec_size
+  // col_index in [0, col_size(mat))
+  // row_offset in [0, row_size(mat))
+  assert(0 <= row_offset && row_offset < row_size);
+  assert(0 <= col_index && col_index < col_size);
+  assert(vec_size <= (row_size - row_offset));
+  for (int i = 0; i < vec_size; ++i) {
+    vec[i] = mat[(row_offset + i) * col_size + col_index];
+  }
 }
 
 std::ostream& operator<<(std::ostream& os, const Matrix& target) {

--- a/recipe/linear_algebra/matrix.cc
+++ b/recipe/linear_algebra/matrix.cc
@@ -6,8 +6,7 @@
 namespace recipe {
 namespace linear_algebra {
 
-Matrix::Matrix()
-    : num_row_(0), num_col_(0), data_(nullptr) {}
+Matrix::Matrix() : num_row_(0), num_col_(0), data_(nullptr) {}
 
 Matrix::Matrix(const int num_row, const int num_col,
                std::unique_ptr<double[]> data)
@@ -26,9 +25,8 @@ Matrix::Matrix(const Matrix& other)
             data_.get());
 }
 
-Matrix Matrix::Slice(
-    const int row_from, const int row_to, const int col_from, const int col_to) const
-{
+Matrix Matrix::Slice(const int row_from, const int row_to, const int col_from,
+                     const int col_to) const {
   assert(0 <= row_from && row_from <= row_to && row_to < num_row_);
   assert(0 <= col_from && col_from <= col_to && col_to < num_col_);
 
@@ -74,12 +72,8 @@ bool Matrix::operator==(const Matrix& other) const {
 // Free functions
 //
 
-void AssignMatrix(
-    Matrix* assignee,
-    const Matrix& assigner,
-    const int row_offset,
-    const int col_offset)
-{
+void AssignMatrix(Matrix* assignee, const Matrix& assigner,
+                  const int row_offset, const int col_offset) {
   assert(0 <= row_offset && row_offset < assignee->NumRow());
   assert(0 <= col_offset && col_offset < assignee->NumCol());
 
@@ -92,12 +86,8 @@ void AssignMatrix(
   }
 }
 
-void AssignVector(
-    Matrix* assignee,
-    const Vector& assigner,
-    const int row_offset,
-    const int col_offset)
-{
+void AssignVector(Matrix* assignee, const Vector& assigner,
+                  const int row_offset, const int col_offset) {
   assert(0 <= row_offset && row_offset < assignee->NumRow());
   assert(0 <= col_offset && col_offset < assignee->NumCol());
 
@@ -132,15 +122,9 @@ Matrix MakeIdentityMatrix(const int size) {
   return Matrix(size, size, std::move(data));
 }
 
-void GetColumnVector(
-    const double* mat,
-    double* vec,
-    const int col_index,
-    const int row_offset,
-    const int vec_size,
-    const size_t row_size,
-    const size_t col_size)
-{
+void GetColumnVector(const double* mat, double* vec, const int col_index,
+                     const int row_offset, const int vec_size,
+                     const size_t row_size, const size_t col_size) {
   // row_size(mat) - row_offset >= vec_size
   // col_index in [0, col_size(mat))
   // row_offset in [0, row_size(mat))
@@ -152,15 +136,9 @@ void GetColumnVector(
   }
 }
 
-void GetRowVector(
-    const double* mat,
-    double* vec,
-    const int row_index,
-    const int col_offset,
-    const int vec_size,
-    const size_t row_size,
-    const size_t col_size)
-{
+void GetRowVector(const double* mat, double* vec, const int row_index,
+                  const int col_offset, const int vec_size,
+                  const size_t row_size, const size_t col_size) {
   // col_size(mat) - col_offset >= vec_size
   // row_index in [0, row_size(mat))
   // col_offset in [0, col_size(mat))

--- a/recipe/linear_algebra/matrix.h
+++ b/recipe/linear_algebra/matrix.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <memory>
+#include "recipe/linear_algebra/vector.h"
 
 namespace recipe {
 namespace linear_algebra {
@@ -30,6 +31,8 @@ class Matrix {
   ///
   Matrix(const int num_row, const int num_col, std::unique_ptr<double[]> data);
   Matrix(const Matrix& other);
+  Matrix Slice(
+      const int row_from, const int row_to, const int col_from, const int col_to) const;
   double operator()(const int row, const int col) const;
   double& operator()(const int row, const int col);
   Matrix& operator=(const Matrix& other);
@@ -39,6 +42,32 @@ class Matrix {
   inline int NumRow() const { return num_row_; }
   inline int NumCol() const { return num_col_; }
 };
+
+/// @brief assigner must be smalelr than assignee.
+///
+/// @param assignee
+/// @param assigner
+/// @param row_offset
+/// @param col_offset
+/// 
+void AssignMatrix(
+    Matrix* assignee,
+    const Matrix& assigner,
+    const int row_offset,
+    const int col_offset);
+
+/// @brief assigner must be smalelr than assignee.
+///
+/// @param assignee
+/// @param assigner
+/// @param row_offset
+/// @param col_offset
+/// 
+void AssignVector(
+    Matrix* assignee,
+    const Vector& assigner,
+    const int row_offset,
+    const int col_offset);
 
 /// @brief Create matrix from initalizer_list.
 ///
@@ -65,6 +94,24 @@ Matrix MakeMatrix(std::initializer_list<std::initializer_list<double>> list);
 ///
 /// @return (size x size) squared matrix
 Matrix MakeIdentityMatrix(const int size);
+
+/// @brief
+///
+/// @param mat matrix $A$.
+/// @param vec obtained column vector $v$.
+/// @param col_index takes a value from 0 to col_size - 1.
+/// @param row_offset takes a value from 0 to row_size - 1.
+/// @param row_size matrix row size $m$.
+/// @param col_size matrix col size $n$.
+/// 
+void GetColumnVector(
+    const double* mat,
+    double* vec,
+    const int col_index,
+    const int row_offset,
+    const int vec_size,
+    const size_t row_size,
+    const size_t col_size);
 
 std::ostream& operator<<(std::ostream& os, const Matrix& target);
 }  // namespace linear_algebra

--- a/recipe/linear_algebra/matrix.h
+++ b/recipe/linear_algebra/matrix.h
@@ -32,8 +32,8 @@ class Matrix {
   ///
   Matrix(const int num_row, const int num_col, std::unique_ptr<double[]> data);
   Matrix(const Matrix& other);
-  Matrix Slice(
-      const int row_from, const int row_to, const int col_from, const int col_to) const;
+  Matrix Slice(const int row_from, const int row_to, const int col_from,
+               const int col_to) const;
   double operator()(const int row, const int col) const;
   double& operator()(const int row, const int col);
   Matrix& operator=(const Matrix& other);
@@ -50,12 +50,9 @@ class Matrix {
 /// @param assigner
 /// @param row_offset
 /// @param col_offset
-/// 
-void AssignMatrix(
-    Matrix* assignee,
-    const Matrix& assigner,
-    const int row_offset,
-    const int col_offset);
+///
+void AssignMatrix(Matrix* assignee, const Matrix& assigner,
+                  const int row_offset, const int col_offset);
 
 /// @brief assigner must be smalelr than assignee.
 ///
@@ -63,12 +60,9 @@ void AssignMatrix(
 /// @param assigner
 /// @param row_offset
 /// @param col_offset
-/// 
-void AssignVector(
-    Matrix* assignee,
-    const Vector& assigner,
-    const int row_offset,
-    const int col_offset);
+///
+void AssignVector(Matrix* assignee, const Vector& assigner,
+                  const int row_offset, const int col_offset);
 
 /// @brief Create matrix from initalizer_list.
 ///
@@ -104,15 +98,10 @@ Matrix MakeIdentityMatrix(const int size);
 /// @param row_offset takes a value from 0 to row_size - 1.
 /// @param row_size matrix row size $m$.
 /// @param col_size matrix col size $n$.
-/// 
-void GetColumnVector(
-    const double* mat,
-    double* vec,
-    const int col_index,
-    const int row_offset,
-    const int vec_size,
-    const size_t row_size,
-    const size_t col_size);
+///
+void GetColumnVector(const double* mat, double* vec, const int col_index,
+                     const int row_offset, const int vec_size,
+                     const size_t row_size, const size_t col_size);
 
 /// @brief
 ///
@@ -122,15 +111,10 @@ void GetColumnVector(
 /// @param col_offset takes a value from 0 to row_size - 1.
 /// @param row_size matrix row size $m$.
 /// @param col_size matrix col size $n$.
-/// 
-void GetRowVector(
-    const double* mat,
-    double* vec,
-    const int row_index,
-    const int col_offset,
-    const int vec_size,
-    const size_t row_size,
-    const size_t col_size);
+///
+void GetRowVector(const double* mat, double* vec, const int row_index,
+                  const int col_offset, const int vec_size,
+                  const size_t row_size, const size_t col_size);
 
 std::ostream& operator<<(std::ostream& os, const Matrix& target);
 }  // namespace linear_algebra

--- a/recipe/linear_algebra/matrix.h
+++ b/recipe/linear_algebra/matrix.h
@@ -17,6 +17,7 @@ class Matrix {
   std::unique_ptr<double[]> data_;
 
  public:
+  Matrix();
   /// @brief Create matrix without initialization.
   ///
   /// @param num_row
@@ -109,6 +110,24 @@ void GetColumnVector(
     double* vec,
     const int col_index,
     const int row_offset,
+    const int vec_size,
+    const size_t row_size,
+    const size_t col_size);
+
+/// @brief
+///
+/// @param mat matrix $A$.
+/// @param vec obtained column vector $v$.
+/// @param row_index takes a value from 0 to col_size - 1.
+/// @param col_offset takes a value from 0 to row_size - 1.
+/// @param row_size matrix row size $m$.
+/// @param col_size matrix col size $n$.
+/// 
+void GetRowVector(
+    const double* mat,
+    double* vec,
+    const int row_index,
+    const int col_offset,
     const int vec_size,
     const size_t row_size,
     const size_t col_size);

--- a/recipe/linear_algebra/matrix_test.cc
+++ b/recipe/linear_algebra/matrix_test.cc
@@ -1,6 +1,6 @@
 #include "recipe/linear_algebra/matrix.h"
-#include "recipe/test_util/test_util.h"
 #include <gtest/gtest.h>
+#include "recipe/test_util/test_util.h"
 
 namespace recipe {
 namespace linear_algebra {
@@ -51,27 +51,27 @@ TEST(MatrixTest, SliceExample) {
 //
 TEST(AssignMatrixTest, SimpleExample) {
   Matrix assignee = MakeMatrix(
-    // clang-format off
+      // clang-format off
     {
     {1, 2, 3,},
     {4, 5, 6,},
     {7, 8, 9,},
-    // clang-format on
-  });
+          // clang-format on
+      });
   const Matrix assigner = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {11, 12,},
     {14, 15,},
-    // clang-format on
+      // clang-format on
   });
   const Matrix expect = MakeMatrix(
-    // clang-format off
+      // clang-format off
     {
     {1, 2, 3,},
     {4, 11, 12,},
     {7, 14, 15,},
-    // clang-format on
-  });
+          // clang-format on
+      });
   AssignMatrix(&assignee, assigner, 1, 1);
   EXPECT_EQ(expect, assignee);
 }
@@ -79,18 +79,18 @@ TEST(AssignMatrixTest, SimpleExample) {
 #ifndef NDEBUG
 TEST(AssignMatrixTest, AssertCase) {
   Matrix assignee = MakeMatrix(
-    // clang-format off
+      // clang-format off
     {
     {1, 2, 3,},
     {4, 5, 6,},
     {7, 8, 9,},
-    // clang-format on
-  });
+          // clang-format on
+      });
   const Matrix assigner = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {11, 12,},
     {14, 15,},
-    // clang-format on
+      // clang-format on
   });
   EXPECT_ASSERT_FAIL(AssignMatrix(&assignee, assigner, -1, 1));
   EXPECT_ASSERT_FAIL(AssignMatrix(&assignee, assigner, 1, -1));
@@ -101,11 +101,11 @@ TEST(AssignMatrixTest, AssertCase) {
 
 TEST(MakeMatrixTest, SquaredMatrixExample) {
   Matrix actual = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {1, 2, 3,},
     {4, 5, 6,},
     {7, 8, 9,},
-    // clang-format on
+      // clang-format on
   });
   Matrix expect(3, 3);
   for (int row = 0; row < 3; ++row) {
@@ -118,12 +118,12 @@ TEST(MakeMatrixTest, SquaredMatrixExample) {
 
 TEST(MakeMatrixTest, NonSquaredMatrixExample0) {
   Matrix actual = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {1, 2, 3,},
     {4, 5, 6,},
     {7, 8, 9,},
     {10, 11, 12},
-    // clang-format on
+      // clang-format on
   });
   Matrix expect(4, 3);
   for (int row = 0; row < 4; ++row) {
@@ -136,11 +136,11 @@ TEST(MakeMatrixTest, NonSquaredMatrixExample0) {
 
 TEST(MakeMatrixTest, NonSquaredMatrixExample1) {
   Matrix actual = MakeMatrix({
-    // clang-format off
+      // clang-format off
     {1, 2, 3, 4},
     {5, 6, 7, 8},
     {9, 10, 11, 12},
-    // clang-format on
+      // clang-format on
   });
   Matrix expect(3, 4);
   for (int row = 0; row < expect.NumRow(); ++row) {
@@ -179,15 +179,14 @@ class GetColumnVectorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     data0_ = MakeMatrix({
-      // clang-format off
+        // clang-format off
       {1, 2, 3},
       {4, 5, 6},
       {7, 8, 9},
-      // clang-format on
+        // clang-format on
     });
   }
-  void TearDown() override {
-  }
+  void TearDown() override {}
   Matrix data0_;
 };
 
@@ -196,8 +195,8 @@ TEST_F(GetColumnVectorTest, Example0) {
   const int col_index = 0;
   const int row_offset = 1;
   const int vec_size = vec.Size();
-  GetColumnVector(
-      data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol());
+  GetColumnVector(data0_.Get(), vec.Get(), col_index, row_offset, vec_size,
+                  data0_.NumRow(), data0_.NumCol());
   const Vector expect = MakeVector({4, 7});
   EXPECT_EQ(expect, vec);
 }
@@ -207,58 +206,63 @@ TEST_F(GetColumnVectorTest, Example1) {
   const int col_index = 2;
   const int row_offset = 0;
   const int vec_size = vec.Size();
-  GetColumnVector(
-      data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol());
+  GetColumnVector(data0_.Get(), vec.Get(), col_index, row_offset, vec_size,
+                  data0_.NumRow(), data0_.NumCol());
   const Vector expect = MakeVector({3, 6, 9});
   EXPECT_EQ(expect, vec);
 }
 
 #ifndef NDEBUG
-  TEST_F(GetColumnVectorTest, ColIndexIsLargerThanMatrixSize) {
-    Vector vec(3);
-    const int col_index = 3;
-    const int row_offset = 0;
-    const int vec_size = vec.Size();
+TEST_F(GetColumnVectorTest, ColIndexIsLargerThanMatrixSize) {
+  Vector vec(3);
+  const int col_index = 3;
+  const int row_offset = 0;
+  const int vec_size = vec.Size();
 
-    EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
-  }
+  EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index,
+                                     row_offset, vec_size, data0_.NumRow(),
+                                     data0_.NumCol()));
+}
 
-  TEST_F(GetColumnVectorTest, RowOffsetIsLargerThanMatrixSize) {
-    Vector vec(3);
-    const int col_index = 2;
-    const int row_offset = 3;
-    const int vec_size = vec.Size();
+TEST_F(GetColumnVectorTest, RowOffsetIsLargerThanMatrixSize) {
+  Vector vec(3);
+  const int col_index = 2;
+  const int row_offset = 3;
+  const int vec_size = vec.Size();
 
-    EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
-  }
+  EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index,
+                                     row_offset, vec_size, data0_.NumRow(),
+                                     data0_.NumCol()));
+}
 
-  TEST_F(GetColumnVectorTest, VecSizeIsLargerThanMatrixSize) {
-    Vector vec(4);
-    const int col_index = 2;
-    const int row_offset = 0;
-    const int vec_size = vec.Size();
+TEST_F(GetColumnVectorTest, VecSizeIsLargerThanMatrixSize) {
+  Vector vec(4);
+  const int col_index = 2;
+  const int row_offset = 0;
+  const int vec_size = vec.Size();
 
-    EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
-  }
-#endif // #ifndef NDEBUG
+  EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index,
+                                     row_offset, vec_size, data0_.NumRow(),
+                                     data0_.NumCol()));
+}
+#endif  // #ifndef NDEBUG
 
 //
 // GetRowVector
 //
 
-class GetRowVectorTest: public ::testing::Test {
+class GetRowVectorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     data0_ = MakeMatrix({
-      // clang-format off
+        // clang-format off
       {1, 2, 3},
       {4, 5, 6},
       {7, 8, 9},
-      // clang-format on
+        // clang-format on
     });
   }
-  void TearDown() override {
-  }
+  void TearDown() override {}
   Matrix data0_;
 };
 
@@ -267,8 +271,8 @@ TEST_F(GetRowVectorTest, Example0) {
   const int row_index = 0;
   const int col_offset = 1;
   const int vec_size = vec.Size();
-  GetRowVector(
-      data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol());
+  GetRowVector(data0_.Get(), vec.Get(), row_index, col_offset, vec_size,
+               data0_.NumRow(), data0_.NumCol());
   const Vector expect = MakeVector({2, 3});
   EXPECT_EQ(expect, vec);
 }
@@ -278,40 +282,46 @@ TEST_F(GetRowVectorTest, Example1) {
   const int row_index = 2;
   const int col_offset = 0;
   const int vec_size = vec.Size();
-  GetRowVector(
-      data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol());
+  GetRowVector(data0_.Get(), vec.Get(), row_index, col_offset, vec_size,
+               data0_.NumRow(), data0_.NumCol());
   const Vector expect = MakeVector({7, 8, 9});
   EXPECT_EQ(expect, vec);
 }
 
 #ifndef NDEBUG
-  TEST_F(GetRowVectorTest, RowIndexIsLargerThanMatrixSize) {
-    Vector vec(3);
-    const int row_index = 3;
-    const int col_offset = 0;
-    const int vec_size = vec.Size();
+TEST_F(GetRowVectorTest, RowIndexIsLargerThanMatrixSize) {
+  Vector vec(3);
+  const int row_index = 3;
+  const int col_offset = 0;
+  const int vec_size = vec.Size();
 
-    EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
-  }
+  EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index,
+                                  col_offset, vec_size, data0_.NumRow(),
+                                  data0_.NumCol()));
+}
 
-  TEST_F(GetRowVectorTest, ColOffsetIsLargerThanMatrixSize) {
-    Vector vec(3);
-    const int row_index = 2;
-    const int col_offset = 3;
-    const int vec_size = vec.Size();
+TEST_F(GetRowVectorTest, ColOffsetIsLargerThanMatrixSize) {
+  Vector vec(3);
+  const int row_index = 2;
+  const int col_offset = 3;
+  const int vec_size = vec.Size();
 
-    EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
-  }
+  EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index,
+                                  col_offset, vec_size, data0_.NumRow(),
+                                  data0_.NumCol()));
+}
 
-  TEST_F(GetRowVectorTest, VecSizeIsLargerThanMatrixSize) {
-    Vector vec(4);
-    const int row_index = 2;
-    const int col_offset = 0;
-    const int vec_size = vec.Size();
+TEST_F(GetRowVectorTest, VecSizeIsLargerThanMatrixSize) {
+  Vector vec(4);
+  const int row_index = 2;
+  const int col_offset = 0;
+  const int vec_size = vec.Size();
 
-    EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
-  }
-#endif // #ifndef NDEBUG
+  EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index,
+                                  col_offset, vec_size, data0_.NumRow(),
+                                  data0_.NumCol()));
+}
+#endif  // #ifndef NDEBUG
 
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/matrix_test.cc
+++ b/recipe/linear_algebra/matrix_test.cc
@@ -99,19 +99,53 @@ TEST(AssignMatrixTest, AssertCase) {
 }
 #endif
 
-TEST(MatrixTest, MakeMatrixTest) {
-  Matrix actual = MakeMatrix(
-      // clang-format off
-      {
-      {1, 2, 3,},
-      {4, 5, 6,},
-      {7, 8, 9,},
-      // clang-format on
-      });
+TEST(MakeMatrixTest, SquaredMatrixExample) {
+  Matrix actual = MakeMatrix({
+    // clang-format off
+    {1, 2, 3,},
+    {4, 5, 6,},
+    {7, 8, 9,},
+    // clang-format on
+  });
   Matrix expect(3, 3);
   for (int row = 0; row < 3; ++row) {
     for (int col = 0; col < 3; ++col) {
       expect(row, col) = row * 3 + col + 1;
+    }
+  }
+  EXPECT_EQ(expect, actual);
+}
+
+TEST(MakeMatrixTest, NonSquaredMatrixExample0) {
+  Matrix actual = MakeMatrix({
+    // clang-format off
+    {1, 2, 3,},
+    {4, 5, 6,},
+    {7, 8, 9,},
+    {10, 11, 12},
+    // clang-format on
+  });
+  Matrix expect(4, 3);
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 3; ++col) {
+      expect(row, col) = row * 3 + col + 1;
+    }
+  }
+  EXPECT_EQ(expect, actual);
+}
+
+TEST(MakeMatrixTest, NonSquaredMatrixExample1) {
+  Matrix actual = MakeMatrix({
+    // clang-format off
+    {1, 2, 3, 4},
+    {5, 6, 7, 8},
+    {9, 10, 11, 12},
+    // clang-format on
+  });
+  Matrix expect(3, 4);
+  for (int row = 0; row < expect.NumRow(); ++row) {
+    for (int col = 0; col < expect.NumCol(); ++col) {
+      expect(row, col) = row * expect.NumCol() + col + 1;
     }
   }
   EXPECT_EQ(expect, actual);
@@ -141,82 +175,143 @@ TEST(MatrixTest, AssertIndexOutOfRange) {
 //
 // GetColumnVector
 //
-Matrix GetColumnVectorSimpleExample() {
-  return MakeMatrix({
-  // clang-format off
-  {1, 2, 3},
-  {4, 5, 6},
-  {7, 8, 9},
-  // clang-format on
-  });
-}
+class GetColumnVectorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    data0_ = MakeMatrix({
+      // clang-format off
+      {1, 2, 3},
+      {4, 5, 6},
+      {7, 8, 9},
+      // clang-format on
+    });
+  }
+  void TearDown() override {
+  }
+  Matrix data0_;
+};
 
-TEST(GetColumnVectorTest, Example0) {
-  Matrix mat = GetColumnVectorSimpleExample();
+TEST_F(GetColumnVectorTest, Example0) {
   Vector vec(2);
   const int col_index = 0;
   const int row_offset = 1;
   const int vec_size = vec.Size();
-  const int row_size = mat.NumRow();
-  const int col_size = mat.NumCol();
   GetColumnVector(
-      mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size);
+      data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol());
   const Vector expect = MakeVector({4, 7});
   EXPECT_EQ(expect, vec);
 }
 
-TEST(GetColumnVectorTest, Example1) {
-  Matrix mat = GetColumnVectorSimpleExample();
+TEST_F(GetColumnVectorTest, Example1) {
   Vector vec(3);
   const int col_index = 2;
   const int row_offset = 0;
   const int vec_size = vec.Size();
-  const int row_size = mat.NumRow();
-  const int col_size = mat.NumCol();
   GetColumnVector(
-      mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size);
+      data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol());
   const Vector expect = MakeVector({3, 6, 9});
   EXPECT_EQ(expect, vec);
 }
 
 #ifndef NDEBUG
-  TEST(GetColumnVectorTest, ColIndexIsLargerThanMatrixSize) {
-    Matrix mat = GetColumnVectorSimpleExample();
+  TEST_F(GetColumnVectorTest, ColIndexIsLargerThanMatrixSize) {
     Vector vec(3);
     const int col_index = 3;
     const int row_offset = 0;
     const int vec_size = vec.Size();
-    const int row_size = mat.NumRow();
-    const int col_size = mat.NumCol();
 
-    EXPECT_DEATH(GetColumnVector(mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size), "Assertion");
+    EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
   }
 
-  TEST(GetColumnVectorTest, RowOffsetIsLargerThanMatrixSize) {
-    Matrix mat = GetColumnVectorSimpleExample();
+  TEST_F(GetColumnVectorTest, RowOffsetIsLargerThanMatrixSize) {
     Vector vec(3);
     const int col_index = 2;
     const int row_offset = 3;
     const int vec_size = vec.Size();
-    const int row_size = mat.NumRow();
-    const int col_size = mat.NumCol();
 
-    EXPECT_DEATH(GetColumnVector(mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size), "Assertion");
+    EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
   }
 
-  TEST(GetColumnVectorTest, VecSizeIsLargerThanMatrixSize) {
-    Matrix mat = GetColumnVectorSimpleExample();
+  TEST_F(GetColumnVectorTest, VecSizeIsLargerThanMatrixSize) {
     Vector vec(4);
     const int col_index = 2;
     const int row_offset = 0;
     const int vec_size = vec.Size();
-    const int row_size = mat.NumRow();
-    const int col_size = mat.NumCol();
 
-    EXPECT_DEATH(GetColumnVector(mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size), "Assertion");
+    EXPECT_ASSERT_FAIL(GetColumnVector(data0_.Get(), vec.Get(), col_index, row_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
   }
 #endif // #ifndef NDEBUG
 
+//
+// GetRowVector
+//
+
+class GetRowVectorTest: public ::testing::Test {
+ protected:
+  void SetUp() override {
+    data0_ = MakeMatrix({
+      // clang-format off
+      {1, 2, 3},
+      {4, 5, 6},
+      {7, 8, 9},
+      // clang-format on
+    });
+  }
+  void TearDown() override {
+  }
+  Matrix data0_;
+};
+
+TEST_F(GetRowVectorTest, Example0) {
+  Vector vec(2);
+  const int row_index = 0;
+  const int col_offset = 1;
+  const int vec_size = vec.Size();
+  GetRowVector(
+      data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol());
+  const Vector expect = MakeVector({2, 3});
+  EXPECT_EQ(expect, vec);
+}
+
+TEST_F(GetRowVectorTest, Example1) {
+  Vector vec(3);
+  const int row_index = 2;
+  const int col_offset = 0;
+  const int vec_size = vec.Size();
+  GetRowVector(
+      data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol());
+  const Vector expect = MakeVector({7, 8, 9});
+  EXPECT_EQ(expect, vec);
+}
+
+#ifndef NDEBUG
+  TEST_F(GetRowVectorTest, RowIndexIsLargerThanMatrixSize) {
+    Vector vec(3);
+    const int row_index = 3;
+    const int col_offset = 0;
+    const int vec_size = vec.Size();
+
+    EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
+  }
+
+  TEST_F(GetRowVectorTest, ColOffsetIsLargerThanMatrixSize) {
+    Vector vec(3);
+    const int row_index = 2;
+    const int col_offset = 3;
+    const int vec_size = vec.Size();
+
+    EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
+  }
+
+  TEST_F(GetRowVectorTest, VecSizeIsLargerThanMatrixSize) {
+    Vector vec(4);
+    const int row_index = 2;
+    const int col_offset = 0;
+    const int vec_size = vec.Size();
+
+    EXPECT_ASSERT_FAIL(GetRowVector(data0_.Get(), vec.Get(), row_index, col_offset, vec_size, data0_.NumRow(), data0_.NumCol()));
+  }
+#endif // #ifndef NDEBUG
 
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/matrix_test.cc
+++ b/recipe/linear_algebra/matrix_test.cc
@@ -1,4 +1,5 @@
 #include "recipe/linear_algebra/matrix.h"
+#include "recipe/test_util/test_util.h"
 #include <gtest/gtest.h>
 
 namespace recipe {
@@ -24,6 +25,80 @@ TEST(MatrixTest, AssignmentOperator) {
   EXPECT_EQ(m, mm);
 }
 
+//
+// Matrix::Slice
+//
+TEST(MatrixTest, SliceExample) {
+  Matrix data = MakeMatrix({
+      // clang-format off
+      {1, 2, 3,},
+      {4, 5, 6,},
+      {7, 8, 9,},
+      // clang-format on
+  });
+  const Matrix actual = data.Slice(1, 2, 1, 2);
+  Matrix expect = MakeMatrix({
+      // clang-format off
+      {5, 6,},
+      {8, 9,},
+      // clang-format on
+  });
+  EXPECT_EQ(expect, actual);
+}
+
+//
+// Free functions
+//
+TEST(AssignMatrixTest, SimpleExample) {
+  Matrix assignee = MakeMatrix(
+    // clang-format off
+    {
+    {1, 2, 3,},
+    {4, 5, 6,},
+    {7, 8, 9,},
+    // clang-format on
+  });
+  const Matrix assigner = MakeMatrix({
+    // clang-format off
+    {11, 12,},
+    {14, 15,},
+    // clang-format on
+  });
+  const Matrix expect = MakeMatrix(
+    // clang-format off
+    {
+    {1, 2, 3,},
+    {4, 11, 12,},
+    {7, 14, 15,},
+    // clang-format on
+  });
+  AssignMatrix(&assignee, assigner, 1, 1);
+  EXPECT_EQ(expect, assignee);
+}
+
+#ifndef NDEBUG
+TEST(AssignMatrixTest, AssertCase) {
+  Matrix assignee = MakeMatrix(
+    // clang-format off
+    {
+    {1, 2, 3,},
+    {4, 5, 6,},
+    {7, 8, 9,},
+    // clang-format on
+  });
+  const Matrix assigner = MakeMatrix({
+    // clang-format off
+    {11, 12,},
+    {14, 15,},
+    // clang-format on
+  });
+  EXPECT_ASSERT_FAIL(AssignMatrix(&assignee, assigner, -1, 1));
+  EXPECT_ASSERT_FAIL(AssignMatrix(&assignee, assigner, 1, -1));
+  EXPECT_ASSERT_FAIL(AssignMatrix(&assignee, assigner, 2, 1));
+  EXPECT_ASSERT_FAIL(AssignMatrix(&assignee, assigner, 1, 2));
+}
+#endif
+
 TEST(MatrixTest, MakeMatrixTest) {
   Matrix actual = MakeMatrix(
       // clang-format off
@@ -31,7 +106,7 @@ TEST(MatrixTest, MakeMatrixTest) {
       {1, 2, 3,},
       {4, 5, 6,},
       {7, 8, 9,},
-          // clang-format on
+      // clang-format on
       });
   Matrix expect(3, 3);
   for (int row = 0; row < 3; ++row) {
@@ -62,6 +137,86 @@ TEST(MatrixTest, AssertIndexOutOfRange) {
   EXPECT_DEATH(m(0, 3), "Assertion *");
 }
 #endif
+
+//
+// GetColumnVector
+//
+Matrix GetColumnVectorSimpleExample() {
+  return MakeMatrix({
+  // clang-format off
+  {1, 2, 3},
+  {4, 5, 6},
+  {7, 8, 9},
+  // clang-format on
+  });
+}
+
+TEST(GetColumnVectorTest, Example0) {
+  Matrix mat = GetColumnVectorSimpleExample();
+  Vector vec(2);
+  const int col_index = 0;
+  const int row_offset = 1;
+  const int vec_size = vec.Size();
+  const int row_size = mat.NumRow();
+  const int col_size = mat.NumCol();
+  GetColumnVector(
+      mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size);
+  const Vector expect = MakeVector({4, 7});
+  EXPECT_EQ(expect, vec);
+}
+
+TEST(GetColumnVectorTest, Example1) {
+  Matrix mat = GetColumnVectorSimpleExample();
+  Vector vec(3);
+  const int col_index = 2;
+  const int row_offset = 0;
+  const int vec_size = vec.Size();
+  const int row_size = mat.NumRow();
+  const int col_size = mat.NumCol();
+  GetColumnVector(
+      mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size);
+  const Vector expect = MakeVector({3, 6, 9});
+  EXPECT_EQ(expect, vec);
+}
+
+#ifndef NDEBUG
+  TEST(GetColumnVectorTest, ColIndexIsLargerThanMatrixSize) {
+    Matrix mat = GetColumnVectorSimpleExample();
+    Vector vec(3);
+    const int col_index = 3;
+    const int row_offset = 0;
+    const int vec_size = vec.Size();
+    const int row_size = mat.NumRow();
+    const int col_size = mat.NumCol();
+
+    EXPECT_DEATH(GetColumnVector(mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size), "Assertion");
+  }
+
+  TEST(GetColumnVectorTest, RowOffsetIsLargerThanMatrixSize) {
+    Matrix mat = GetColumnVectorSimpleExample();
+    Vector vec(3);
+    const int col_index = 2;
+    const int row_offset = 3;
+    const int vec_size = vec.Size();
+    const int row_size = mat.NumRow();
+    const int col_size = mat.NumCol();
+
+    EXPECT_DEATH(GetColumnVector(mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size), "Assertion");
+  }
+
+  TEST(GetColumnVectorTest, VecSizeIsLargerThanMatrixSize) {
+    Matrix mat = GetColumnVectorSimpleExample();
+    Vector vec(4);
+    const int col_index = 2;
+    const int row_offset = 0;
+    const int vec_size = vec.Size();
+    const int row_size = mat.NumRow();
+    const int col_size = mat.NumCol();
+
+    EXPECT_DEATH(GetColumnVector(mat.Get(), vec.Get(), col_index, row_offset, vec_size, row_size, col_size), "Assertion");
+  }
+#endif // #ifndef NDEBUG
+
 
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/operator_binary.cc
+++ b/recipe/linear_algebra/operator_binary.cc
@@ -34,6 +34,15 @@ std::unique_ptr<double[]> Multiply(
   return data;
 }
 
+double InnerProduct(const double* vec_lhs, const double* vec_rhs, const int size)
+{
+  double sum = 0.0;
+  for (int i = 0; i < size; ++i) {
+    sum += vec_lhs[i] * vec_rhs[i];
+  }
+  return sum;
+}
+
 Vector Multiply(const Matrix& mat, const Vector& vec) {
   assert(mat.NumRow() == vec.Size());
   const int row_size = mat.NumRow();

--- a/recipe/linear_algebra/operator_binary.cc
+++ b/recipe/linear_algebra/operator_binary.cc
@@ -1,6 +1,7 @@
 #include "recipe/linear_algebra/operator_binary.h"
 #include <cassert>
 #include "recipe/linear_algebra/base.h"
+#include "recipe/linear_algebra/operator_unary.h"
 
 namespace recipe {
 namespace linear_algebra {
@@ -32,6 +33,17 @@ std::unique_ptr<double[]> Multiply(
     }
   }
   return data;
+}
+
+std::unique_ptr<double[]> MultiplyLeftTranspose(
+    const double* mat_lhs, const int row_size_lhs, const int col_size_lhs,
+    const double* mat_rhs, const int row_size_rhs, const int col_size_rhs)
+{
+  std::unique_ptr<double[]> mat_lhs_transposed = Transpose(mat_lhs, row_size_lhs, col_size_lhs);
+  const int row_size_lhs_t = col_size_lhs;
+  const int col_size_lhs_t = row_size_lhs;
+  return Multiply(mat_lhs_transposed.get(), row_size_lhs_t, col_size_lhs_t,
+                  mat_rhs, row_size_rhs, col_size_rhs);
 }
 
 double InnerProduct(const double* vec_lhs, const double* vec_rhs, const int size)

--- a/recipe/linear_algebra/operator_binary.cc
+++ b/recipe/linear_algebra/operator_binary.cc
@@ -37,17 +37,17 @@ std::unique_ptr<double[]> Multiply(
 
 std::unique_ptr<double[]> MultiplyLeftTranspose(
     const double* mat_lhs, const int row_size_lhs, const int col_size_lhs,
-    const double* mat_rhs, const int row_size_rhs, const int col_size_rhs)
-{
-  std::unique_ptr<double[]> mat_lhs_transposed = Transpose(mat_lhs, row_size_lhs, col_size_lhs);
+    const double* mat_rhs, const int row_size_rhs, const int col_size_rhs) {
+  std::unique_ptr<double[]> mat_lhs_transposed =
+      Transpose(mat_lhs, row_size_lhs, col_size_lhs);
   const int row_size_lhs_t = col_size_lhs;
   const int col_size_lhs_t = row_size_lhs;
   return Multiply(mat_lhs_transposed.get(), row_size_lhs_t, col_size_lhs_t,
                   mat_rhs, row_size_rhs, col_size_rhs);
 }
 
-double InnerProduct(const double* vec_lhs, const double* vec_rhs, const int size)
-{
+double InnerProduct(const double* vec_lhs, const double* vec_rhs,
+                    const int size) {
   double sum = 0.0;
   for (int i = 0; i < size; ++i) {
     sum += vec_lhs[i] * vec_rhs[i];

--- a/recipe/linear_algebra/operator_binary.h
+++ b/recipe/linear_algebra/operator_binary.h
@@ -6,7 +6,7 @@
 namespace recipe {
 namespace linear_algebra {
 /// @brief Compute $Ax$, multiplication of a matrix and a vector.
-///   
+///
 ///
 /// @param mat matrix $A$.
 /// @param row_size
@@ -14,7 +14,7 @@ namespace linear_algebra {
 /// @param vec vector $x$.
 ///
 /// @return $Ax$
-/// 
+///
 std::unique_ptr<double[]> Multiply(const double* mat, const int row_size,
                                    const int col_size, const double* vec);
 /// @brief Compute $AB$, multiplication of two matrice.
@@ -47,7 +47,8 @@ std::unique_ptr<double[]> MultiplyLeftTranspose(
     const double* mat_lhs, const int row_size_lhs, const int col_size_lhs,
     const double* mat_rhs, const int row_size_rhs, const int col_size_rhs);
 
-double InnerProduct(const double* vec_lhs, const double* vec_rhs, const int size);
+double InnerProduct(const double* vec_lhs, const double* vec_rhs,
+                    const int size);
 
 Vector Multiply(const Matrix& mat, const Vector& vec);
 Matrix Multiply(const Matrix& mat_lhs, const Matrix& mat_rhs);

--- a/recipe/linear_algebra/operator_binary.h
+++ b/recipe/linear_algebra/operator_binary.h
@@ -5,9 +5,45 @@
 
 namespace recipe {
 namespace linear_algebra {
+/// @brief Compute $Ax$, multiplication of a matrix and a vector.
+///   
+///
+/// @param mat matrix $A$.
+/// @param row_size
+/// @param col_size
+/// @param vec vector $x$.
+///
+/// @return $Ax$
+/// 
 std::unique_ptr<double[]> Multiply(const double* mat, const int row_size,
                                    const int col_size, const double* vec);
+/// @brief Compute $AB$, multiplication of two matrice.
+///
+/// @param mat_lhs $A$
+/// @param row_size_lhs
+/// @param col_size_lhs
+/// @param mat_rhs $B$
+/// @param row_size_rhs
+/// @param col_size_rhs
+///
+/// @return $AB$.
+///
 std::unique_ptr<double[]> Multiply(
+    const double* mat_lhs, const int row_size_lhs, const int col_size_lhs,
+    const double* mat_rhs, const int row_size_rhs, const int col_size_rhs);
+
+/// @brief Compute $A^{\\mathrm{T}}B$, multiplication of two matrice.
+///
+/// @param mat_lhs matrix $A$
+/// @param row_size_lhs
+/// @param col_size_lhs
+/// @param mat_rhs matrix $B$
+/// @param row_size_rhs
+/// @param col_size_rhs
+///
+/// @return matrix $A^{\\mathrm{T}}B$.
+///
+std::unique_ptr<double[]> MultiplyLeftTranspose(
     const double* mat_lhs, const int row_size_lhs, const int col_size_lhs,
     const double* mat_rhs, const int row_size_rhs, const int col_size_rhs);
 

--- a/recipe/linear_algebra/operator_binary.h
+++ b/recipe/linear_algebra/operator_binary.h
@@ -11,6 +11,8 @@ std::unique_ptr<double[]> Multiply(
     const double* mat_lhs, const int row_size_lhs, const int col_size_lhs,
     const double* mat_rhs, const int row_size_rhs, const int col_size_rhs);
 
+double InnerProduct(const double* vec_lhs, const double* vec_rhs, const int size);
+
 Vector Multiply(const Matrix& mat, const Vector& vec);
 Matrix Multiply(const Matrix& mat_lhs, const Matrix& mat_rhs);
 }  // namespace linear_algebra

--- a/recipe/linear_algebra/operator_binary_test.cc
+++ b/recipe/linear_algebra/operator_binary_test.cc
@@ -1,6 +1,6 @@
 #include "recipe/linear_algebra/operator_binary.h"
-#include "recipe/linear_algebra/operator_unary.h"
 #include <gtest/gtest.h>
+#include "recipe/linear_algebra/operator_unary.h"
 #include "recipe/linear_algebra/test_util/gtest_assertion.h"
 #include "recipe/linear_algebra/test_util/test_data.h"
 #include "recipe/linear_algebra/util.h"
@@ -56,23 +56,23 @@ TEST(MultiplyLeftTransposeTest, BidiagonalExample) {
   const int row_size = 4;
   const int col_size = 5;
   double mat[] = {
-    // clang-format off
+      // clang-format off
      1, 2, 0, 0, 0,
      0, 3, 4, 0, 0,
      0, 0, 5, 6, 0,
      0, 0, 0, 7, 8,
-    // clang-format on
+      // clang-format on
   };
-  std::unique_ptr<double[]> actual = MultiplyLeftTranspose(
-      mat, row_size, col_size, mat, row_size, col_size);
+  std::unique_ptr<double[]> actual =
+      MultiplyLeftTranspose(mat, row_size, col_size, mat, row_size, col_size);
   double expect[] = {
-     // clang-format off
+      // clang-format off
      1, 2,  0,  0,  0,
      2, 13, 12, 0,  0,
      0, 12, 41, 30, 0,
      0, 0,  30, 85, 56,
      0, 0,  0,  56, 64,
-     // clang-format on
+      // clang-format on
   };
   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, col_size * col_size);
 }

--- a/recipe/linear_algebra/operator_binary_test.cc
+++ b/recipe/linear_algebra/operator_binary_test.cc
@@ -1,4 +1,5 @@
 #include "recipe/linear_algebra/operator_binary.h"
+#include "recipe/linear_algebra/operator_unary.h"
 #include <gtest/gtest.h>
 #include "recipe/linear_algebra/test_util/gtest_assertion.h"
 #include "recipe/linear_algebra/test_util/test_data.h"
@@ -49,6 +50,16 @@ TEST(MultiplyTest, MatrixArrayTimesMatrixArray) {
       // clang-format on
   });
   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, row_size);
+}
+
+TEST(InnerProductTest, EnsureRelationToNorm) {
+  const int size = 3;
+  std::unique_ptr<double[]> vec = TestData::GetRandomDoublePointer(size);
+  const double actual = InnerProduct(vec.get(), vec.get(), size);
+  // norm
+  const double norm = NormEuclid(vec.get(), size);
+  const double expect = norm * norm;
+  EXPECT_NEAR(expect, actual, std::numeric_limits<double>::epsilon());
 }
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/operator_binary_test.cc
+++ b/recipe/linear_algebra/operator_binary_test.cc
@@ -30,14 +30,14 @@ TEST(MultiplyTest, MatrixArrayTimesMatrixArray) {
   const int col_size = 2;
   std::unique_ptr<double[]> mat_lhs = MakeDoubleArray({
       // clang-format off
-                                                 1, 2,
-                                                 3, 4,
+       1, 2,
+       3, 4,
       // clang-format on
   });
   std::unique_ptr<double[]> mat_rhs = MakeDoubleArray({
       // clang-format off
-                                                 2, -1,
-                                                 1, -2,
+         2, -1,
+         1, -2,
       // clang-format on
   });
   std::unique_ptr<double[]> actual = Multiply(
@@ -50,6 +50,31 @@ TEST(MultiplyTest, MatrixArrayTimesMatrixArray) {
       // clang-format on
   });
   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, row_size);
+}
+
+TEST(MultiplyLeftTransposeTest, BidiagonalExample) {
+  const int row_size = 4;
+  const int col_size = 5;
+  double mat[] = {
+    // clang-format off
+     1, 2, 0, 0, 0,
+     0, 3, 4, 0, 0,
+     0, 0, 5, 6, 0,
+     0, 0, 0, 7, 8,
+    // clang-format on
+  };
+  std::unique_ptr<double[]> actual = MultiplyLeftTranspose(
+      mat, row_size, col_size, mat, row_size, col_size);
+  double expect[] = {
+     // clang-format off
+     1, 2,  0,  0,  0,
+     2, 13, 12, 0,  0,
+     0, 12, 41, 30, 0,
+     0, 0,  30, 85, 56,
+     0, 0,  0,  56, 64,
+     // clang-format on
+  };
+  EXPECT_ARRAY_ELEMENT_EQ(expect, actual, col_size * col_size);
 }
 
 TEST(InnerProductTest, EnsureRelationToNorm) {

--- a/recipe/linear_algebra/operator_unary.cc
+++ b/recipe/linear_algebra/operator_unary.cc
@@ -1,5 +1,6 @@
 #include "recipe/linear_algebra/operator_unary.h"
 #include <cmath>
+#include "recipe/linear_algebra/base.h"
 
 namespace recipe {
 namespace linear_algebra {
@@ -14,6 +15,17 @@ double NormEuclid(const double* vec, const int size) {
 double NormEuclid(const Vector vec)
 {
   return NormEuclid(vec.Get(), vec.Size());
+}
+
+std::unique_ptr<double[]> Transpose(const double* mat, const int row_size, const int col_size)
+{
+  std::unique_ptr<double[]> data(new double[row_size * col_size]);
+  for (int row = 0; row < row_size; ++row) {
+    for (int col = 0; col < col_size; ++col) {
+      MATRIX(data, row_size, col, row) = MATRIX(mat, col_size, row, col);
+    }
+  }
+  return data;
 }
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/operator_unary.cc
+++ b/recipe/linear_algebra/operator_unary.cc
@@ -12,13 +12,12 @@ double NormEuclid(const double* vec, const int size) {
   return std::sqrt(sum);
 }
 
-double NormEuclid(const Vector vec)
-{
+double NormEuclid(const Vector vec) {
   return NormEuclid(vec.Get(), vec.Size());
 }
 
-std::unique_ptr<double[]> Transpose(const double* mat, const int row_size, const int col_size)
-{
+std::unique_ptr<double[]> Transpose(const double* mat, const int row_size,
+                                    const int col_size) {
   std::unique_ptr<double[]> data(new double[row_size * col_size]);
   for (int row = 0; row < row_size; ++row) {
     for (int col = 0; col < col_size; ++col) {

--- a/recipe/linear_algebra/operator_unary.cc
+++ b/recipe/linear_algebra/operator_unary.cc
@@ -9,7 +9,11 @@ double NormEuclid(const double* vec, const int size) {
     sum += vec[i] * vec[i];
   }
   return std::sqrt(sum);
-  ;
+}
+
+double NormEuclid(const Vector vec)
+{
+  return NormEuclid(vec.Get(), vec.Size());
 }
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/operator_unary.h
+++ b/recipe/linear_algebra/operator_unary.h
@@ -1,7 +1,9 @@
 #pragma once
+#include "recipe/linear_algebra/vector.h"
 
 namespace recipe {
 namespace linear_algebra {
 double NormEuclid(const double* vec, const int size);
+double NormEuclid(const Vector vec);
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/operator_unary.h
+++ b/recipe/linear_algebra/operator_unary.h
@@ -5,5 +5,6 @@ namespace recipe {
 namespace linear_algebra {
 double NormEuclid(const double* vec, const int size);
 double NormEuclid(const Vector vec);
+std::unique_ptr<double[]> Transpose(const double* mat, const int row_size, const int col_size);
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/operator_unary.h
+++ b/recipe/linear_algebra/operator_unary.h
@@ -5,6 +5,7 @@ namespace recipe {
 namespace linear_algebra {
 double NormEuclid(const double* vec, const int size);
 double NormEuclid(const Vector vec);
-std::unique_ptr<double[]> Transpose(const double* mat, const int row_size, const int col_size);
+std::unique_ptr<double[]> Transpose(const double* mat, const int row_size,
+                                    const int col_size);
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/operator_unary_test.cc
+++ b/recipe/linear_algebra/operator_unary_test.cc
@@ -16,16 +16,13 @@ TEST(NormEuclidTest, Example) {
 
 TEST(TransposeTest, Example) {
   double mat[] = {
-    1, 2, 3,
-    4, 5, 6,
+      1, 2, 3, 4, 5, 6,
   };
   const int row_size = 2;
   const int col_size = 3;
   const std::unique_ptr<double[]> actual = Transpose(mat, row_size, col_size);
   double expect[] = {
-    1, 4,
-    2, 5,
-    3, 6,
+      1, 4, 2, 5, 3, 6,
   };
   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, row_size * col_size);
 }

--- a/recipe/linear_algebra/operator_unary_test.cc
+++ b/recipe/linear_algebra/operator_unary_test.cc
@@ -1,6 +1,7 @@
 #include "recipe/linear_algebra/operator_unary.h"
 #include <gtest/gtest.h>
 #include "recipe/linear_algebra/test_util/test_data.h"
+#include "recipe/test_util/test_util.h"
 
 namespace recipe {
 namespace linear_algebra {
@@ -11,6 +12,22 @@ TEST(NormEuclidTest, Example) {
   const double expect =
       std::sqrt(data[0] * data[0] + data[1] * data[1] + data[2] * data[2]);
   EXPECT_EQ(expect, actual);
+}
+
+TEST(TransposeTest, Example) {
+  double mat[] = {
+    1, 2, 3,
+    4, 5, 6,
+  };
+  const int row_size = 2;
+  const int col_size = 3;
+  const std::unique_ptr<double[]> actual = Transpose(mat, row_size, col_size);
+  double expect[] = {
+    1, 4,
+    2, 5,
+    3, 6,
+  };
+  EXPECT_ARRAY_ELEMENT_EQ(expect, actual, row_size * col_size);
 }
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/qr_decomposition.cc
+++ b/recipe/linear_algebra/qr_decomposition.cc
@@ -1,0 +1,192 @@
+#include "recipe/linear_algebra/qr_decomposition.h"
+#include <cassert>
+#include <cmath>
+#include <numeric>
+#include <stdexcept>
+#include "recipe/linear_algebra/base.h"
+#include "recipe/linear_algebra/householder.h"
+#include "recipe/linear_algebra/operator_binary.h"
+#include "recipe/linear_algebra/util.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+//
+// HouseholderQR
+//
+
+std::unique_ptr<double[]>
+ComputeHouseholderQR(double* mat_a, const int row_size, const int col_size) {
+  assert(row_size >= col_size);
+  // to compute Q explicitly
+  std::unique_ptr<double[]> householder_coeffs(new double[col_size]);
+  double householder_vec[row_size];
+  double vec_col[row_size];
+
+  for (int j = 0; j < col_size; ++j) {
+    const int vec_size = row_size - j;
+    householder_coeffs[j] = 0.0;
+    // compute householder vector
+    GetColumnVector(mat_a, vec_col, j, j, vec_size, row_size, col_size);
+    ComputeHouseholderVector(vec_col, vec_size, householder_vec, &householder_coeffs[j]);
+    // compute householder matrix
+    std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
+        householder_vec, householder_coeffs[j], vec_size);
+
+    // (I - beta vv^{T}) A[j:(row_size-1), j:(col_size-1)]
+    double mat_temp[row_size * col_size];
+    for (int row = j; row < row_size; ++row) {
+      for (int col = j; col< col_size; ++col) {
+        double sum = 0.0;
+        for (int k = 0; k < vec_size; ++k) {
+          sum += (MATRIX(householder_mat, vec_size, row - j, k)
+                  * MATRIX(mat_a, col_size, j + k, col));
+        }
+        MATRIX(mat_temp, col_size, row, col) = sum;
+      }
+    }
+    for (int row = j; row < row_size; ++row) {
+      for (int col = j; col < col_size; ++col) {
+        MATRIX(mat_a, col_size, row, col) = MATRIX(mat_temp, col_size, row, col);
+      }
+    }
+
+    // store householder vector to mat_a
+    if (j < col_size - 1) {
+      for (int row = j + 1; row < row_size; ++row) {
+        MATRIX(mat_a, col_size, row, j) = householder_vec[row - j];
+      }
+    }
+  }
+
+  return householder_coeffs;
+}
+
+// Compute
+// mat(row_from:row_to, col_from, col_to)
+std::unique_ptr<double[]> Multiply(
+    const double* householder_vec,
+    const double householder_coeff,
+    const double* mat_a,
+    const int row_size,
+    const int col_size,
+    const int row_from,
+    const int row_to,
+    const int col_from,
+    const int col_to)
+{
+  // householder_vec == r_size
+  // 
+  // size for returned matrix
+  const int r_size = row_to - row_from + 1;
+  const int c_size = col_to - col_from + 1;
+  // (I - coeff * vec vec^{T})
+  std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
+      householder_vec, householder_coeff, r_size);
+  std::unique_ptr<double[]> data(new double[r_size * c_size]);
+  for (int row = 0; row < r_size; ++row) {
+    for (int col = 0; col < c_size; ++col) {
+      double sum = 0.0;
+      for (int k = 0; k < r_size; ++k) {
+        sum += (MATRIX(householder_mat, r_size, k, col)
+                * MATRIX(mat_a, col_size, row_from + k, col_from + col));
+      }
+      MATRIX(data, col_size, row, col) = sum;
+    }
+  }
+  return data;
+}
+
+std::unique_ptr<double[]>
+ConvertHouseholderQRToR(
+    const double* mat_qr,
+    const double* householder_coeffs,
+    const int row_size,
+    const int col_size) {
+  std::unique_ptr<double[]> mat_r(new double[row_size * col_size]);
+  std::fill(mat_r.get(), mat_r.get() + row_size * col_size, 0.0);
+
+  // R
+  for (int row = 0; row < row_size; ++row) {
+    for (int col = row; col < col_size; ++col) {
+      MATRIX(mat_r, col_size, row, col) = MATRIX(mat_qr, col_size, row, col);
+    }
+  }
+  return mat_r;
+}
+
+std::unique_ptr<double[]>
+ConvertHouseholderQRToQ(
+    const double* mat_qr,
+    const double* householder_coeffs,
+    const int row_size,
+    const int col_size) {
+  // TODO(i05nagai): Support row_size < col_size
+  assert(row_size >= col_size);
+  // Q^{factor}
+  const int q_col_size = row_size;
+  std::unique_ptr<double[]> mat_q(new double[row_size * q_col_size]);
+  for (int row = 0; row < row_size; ++row) {
+    for (int col = 0; col < row_size; ++col) {
+      if (row == col) {
+        MATRIX(mat_q, q_col_size, row, col) = 1.0;
+      } else {
+        MATRIX(mat_q, q_col_size, row, col) = 0.0;
+      }
+    }
+  }
+  double householder_vec[row_size];
+  const int factor = col_size;
+  for (int j = factor - 1; j >= 0; --j) {
+    const int vec_size = row_size - j;
+    // extract householder vector
+    householder_vec[0] = 1.0;
+    for (int row = 1; row < vec_size; ++row) {
+      householder_vec[row] = MATRIX(mat_qr, col_size, row + j, j);
+    }
+    // (I - beta vv^{T}) Q(j:n, j:n)
+    std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
+        householder_vec, householder_coeffs[j], vec_size);
+
+    double mat_q_temp[vec_size * vec_size];
+    for (int row = 0; row < vec_size; ++row) {
+      for (int col = 0; col < vec_size; ++col) {
+        double sum = 0.0;
+        for (int k = 0; k < vec_size; ++k) {
+          sum += (MATRIX(householder_mat, vec_size, row, k)
+                  * MATRIX(mat_q, q_col_size, j + k, col + j));
+        }
+        MATRIX(mat_q_temp, vec_size, row, col) = sum;
+      }
+    }
+    for (int row = 0; row < vec_size; ++row) {
+      for (int col = 0; col < vec_size; ++col) {
+        MATRIX(mat_q, q_col_size, row + j, col + j)
+          = MATRIX(mat_q_temp, vec_size, row, col);
+      }
+    }
+  }
+  return mat_q;
+}
+
+std::pair<std::unique_ptr<double[]>,std::unique_ptr<double[]>>
+ConvertHouseholderQRToQR(
+    const double* mat_qr,
+    const double* householder_coeffs,
+    const int row_size,
+    const int col_size)
+{
+  std::unique_ptr<double[]> mat_r = ConvertHouseholderQRToR(
+      mat_qr, householder_coeffs, row_size, col_size);
+  std::unique_ptr<double[]> mat_q = ConvertHouseholderQRToQ(
+      mat_qr, householder_coeffs, row_size, col_size);
+  return std::make_pair(std::move(mat_q), std::move(mat_r));
+}
+
+//
+// GivensQR
+//
+
+}  // namespace linear_algebra
+}  // namespace recipe
+

--- a/recipe/linear_algebra/qr_decomposition.cc
+++ b/recipe/linear_algebra/qr_decomposition.cc
@@ -65,36 +65,6 @@ std::unique_ptr<double[]> ComputeHouseholderQR(double* mat_a,
   return householder_coeffs;
 }
 
-// Compute
-// mat(row_from:row_to, col_from, col_to)
-std::unique_ptr<double[]> Multiply(const double* householder_vec,
-                                   const double householder_coeff,
-                                   const double* mat_a, const int row_size,
-                                   const int col_size, const int row_from,
-                                   const int row_to, const int col_from,
-                                   const int col_to) {
-  // householder_vec == r_size
-  //
-  // size for returned matrix
-  const int r_size = row_to - row_from + 1;
-  const int c_size = col_to - col_from + 1;
-  // (I - coeff * vec vec^{T})
-  std::unique_ptr<double[]> householder_mat =
-      ComputeHouseholderMatrix(householder_vec, householder_coeff, r_size);
-  std::unique_ptr<double[]> data(new double[r_size * c_size]);
-  for (int row = 0; row < r_size; ++row) {
-    for (int col = 0; col < c_size; ++col) {
-      double sum = 0.0;
-      for (int k = 0; k < r_size; ++k) {
-        sum += (MATRIX(householder_mat, r_size, k, col) *
-                MATRIX(mat_a, col_size, row_from + k, col_from + col));
-      }
-      MATRIX(data, col_size, row, col) = sum;
-    }
-  }
-  return data;
-}
-
 std::unique_ptr<double[]> ConvertHouseholderQRToR(
     const double* mat_qr, const double* householder_coeffs, const int row_size,
     const int col_size) {

--- a/recipe/linear_algebra/qr_decomposition.cc
+++ b/recipe/linear_algebra/qr_decomposition.cc
@@ -15,8 +15,9 @@ namespace linear_algebra {
 // HouseholderQR
 //
 
-std::unique_ptr<double[]>
-ComputeHouseholderQR(double* mat_a, const int row_size, const int col_size) {
+std::unique_ptr<double[]> ComputeHouseholderQR(double* mat_a,
+                                               const int row_size,
+                                               const int col_size) {
   assert(row_size >= col_size);
   // to compute Q explicitly
   std::unique_ptr<double[]> householder_coeffs(new double[col_size]);
@@ -28,7 +29,8 @@ ComputeHouseholderQR(double* mat_a, const int row_size, const int col_size) {
     householder_coeffs[j] = 0.0;
     // compute householder vector
     GetColumnVector(mat_a, vec_col, j, j, vec_size, row_size, col_size);
-    ComputeHouseholderVector(vec_col, vec_size, householder_vec, &householder_coeffs[j]);
+    ComputeHouseholderVector(vec_col, vec_size, householder_vec,
+                             &householder_coeffs[j]);
     // compute householder matrix
     std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
         householder_vec, householder_coeffs[j], vec_size);
@@ -36,18 +38,19 @@ ComputeHouseholderQR(double* mat_a, const int row_size, const int col_size) {
     // (I - beta vv^{T}) A[j:(row_size-1), j:(col_size-1)]
     double mat_temp[row_size * col_size];
     for (int row = j; row < row_size; ++row) {
-      for (int col = j; col< col_size; ++col) {
+      for (int col = j; col < col_size; ++col) {
         double sum = 0.0;
         for (int k = 0; k < vec_size; ++k) {
-          sum += (MATRIX(householder_mat, vec_size, row - j, k)
-                  * MATRIX(mat_a, col_size, j + k, col));
+          sum += (MATRIX(householder_mat, vec_size, row - j, k) *
+                  MATRIX(mat_a, col_size, j + k, col));
         }
         MATRIX(mat_temp, col_size, row, col) = sum;
       }
     }
     for (int row = j; row < row_size; ++row) {
       for (int col = j; col < col_size; ++col) {
-        MATRIX(mat_a, col_size, row, col) = MATRIX(mat_temp, col_size, row, col);
+        MATRIX(mat_a, col_size, row, col) =
+            MATRIX(mat_temp, col_size, row, col);
       }
     }
 
@@ -64,32 +67,27 @@ ComputeHouseholderQR(double* mat_a, const int row_size, const int col_size) {
 
 // Compute
 // mat(row_from:row_to, col_from, col_to)
-std::unique_ptr<double[]> Multiply(
-    const double* householder_vec,
-    const double householder_coeff,
-    const double* mat_a,
-    const int row_size,
-    const int col_size,
-    const int row_from,
-    const int row_to,
-    const int col_from,
-    const int col_to)
-{
+std::unique_ptr<double[]> Multiply(const double* householder_vec,
+                                   const double householder_coeff,
+                                   const double* mat_a, const int row_size,
+                                   const int col_size, const int row_from,
+                                   const int row_to, const int col_from,
+                                   const int col_to) {
   // householder_vec == r_size
-  // 
+  //
   // size for returned matrix
   const int r_size = row_to - row_from + 1;
   const int c_size = col_to - col_from + 1;
   // (I - coeff * vec vec^{T})
-  std::unique_ptr<double[]> householder_mat = ComputeHouseholderMatrix(
-      householder_vec, householder_coeff, r_size);
+  std::unique_ptr<double[]> householder_mat =
+      ComputeHouseholderMatrix(householder_vec, householder_coeff, r_size);
   std::unique_ptr<double[]> data(new double[r_size * c_size]);
   for (int row = 0; row < r_size; ++row) {
     for (int col = 0; col < c_size; ++col) {
       double sum = 0.0;
       for (int k = 0; k < r_size; ++k) {
-        sum += (MATRIX(householder_mat, r_size, k, col)
-                * MATRIX(mat_a, col_size, row_from + k, col_from + col));
+        sum += (MATRIX(householder_mat, r_size, k, col) *
+                MATRIX(mat_a, col_size, row_from + k, col_from + col));
       }
       MATRIX(data, col_size, row, col) = sum;
     }
@@ -97,11 +95,8 @@ std::unique_ptr<double[]> Multiply(
   return data;
 }
 
-std::unique_ptr<double[]>
-ConvertHouseholderQRToR(
-    const double* mat_qr,
-    const double* householder_coeffs,
-    const int row_size,
+std::unique_ptr<double[]> ConvertHouseholderQRToR(
+    const double* mat_qr, const double* householder_coeffs, const int row_size,
     const int col_size) {
   std::unique_ptr<double[]> mat_r(new double[row_size * col_size]);
   std::fill(mat_r.get(), mat_r.get() + row_size * col_size, 0.0);
@@ -115,11 +110,8 @@ ConvertHouseholderQRToR(
   return mat_r;
 }
 
-std::unique_ptr<double[]>
-ConvertHouseholderQRToQ(
-    const double* mat_qr,
-    const double* householder_coeffs,
-    const int row_size,
+std::unique_ptr<double[]> ConvertHouseholderQRToQ(
+    const double* mat_qr, const double* householder_coeffs, const int row_size,
     const int col_size) {
   // TODO(i05nagai): Support row_size < col_size
   assert(row_size >= col_size);
@@ -153,33 +145,29 @@ ConvertHouseholderQRToQ(
       for (int col = 0; col < vec_size; ++col) {
         double sum = 0.0;
         for (int k = 0; k < vec_size; ++k) {
-          sum += (MATRIX(householder_mat, vec_size, row, k)
-                  * MATRIX(mat_q, q_col_size, j + k, col + j));
+          sum += (MATRIX(householder_mat, vec_size, row, k) *
+                  MATRIX(mat_q, q_col_size, j + k, col + j));
         }
         MATRIX(mat_q_temp, vec_size, row, col) = sum;
       }
     }
     for (int row = 0; row < vec_size; ++row) {
       for (int col = 0; col < vec_size; ++col) {
-        MATRIX(mat_q, q_col_size, row + j, col + j)
-          = MATRIX(mat_q_temp, vec_size, row, col);
+        MATRIX(mat_q, q_col_size, row + j, col + j) =
+            MATRIX(mat_q_temp, vec_size, row, col);
       }
     }
   }
   return mat_q;
 }
 
-std::pair<std::unique_ptr<double[]>,std::unique_ptr<double[]>>
-ConvertHouseholderQRToQR(
-    const double* mat_qr,
-    const double* householder_coeffs,
-    const int row_size,
-    const int col_size)
-{
-  std::unique_ptr<double[]> mat_r = ConvertHouseholderQRToR(
-      mat_qr, householder_coeffs, row_size, col_size);
-  std::unique_ptr<double[]> mat_q = ConvertHouseholderQRToQ(
-      mat_qr, householder_coeffs, row_size, col_size);
+std::pair<std::unique_ptr<double[]>, std::unique_ptr<double[]>>
+ConvertHouseholderQRToQR(const double* mat_qr, const double* householder_coeffs,
+                         const int row_size, const int col_size) {
+  std::unique_ptr<double[]> mat_r =
+      ConvertHouseholderQRToR(mat_qr, householder_coeffs, row_size, col_size);
+  std::unique_ptr<double[]> mat_q =
+      ConvertHouseholderQRToQ(mat_qr, householder_coeffs, row_size, col_size);
   return std::make_pair(std::move(mat_q), std::move(mat_r));
 }
 
@@ -189,4 +177,3 @@ ConvertHouseholderQRToQR(
 
 }  // namespace linear_algebra
 }  // namespace recipe
-

--- a/recipe/linear_algebra/qr_decomposition.cc
+++ b/recipe/linear_algebra/qr_decomposition.cc
@@ -19,7 +19,7 @@ std::unique_ptr<double[]> ComputeHouseholderQR(double* mat_a,
                                                const int row_size,
                                                const int col_size) {
   assert(row_size >= col_size);
-  // to compute Q explicitly
+  // to compute Q explicitly, coeffscients and householder vectors are necessary
   std::unique_ptr<double[]> householder_coeffs(new double[col_size]);
   double householder_vec[row_size];
   double vec_col[row_size];

--- a/recipe/linear_algebra/qr_decomposition.h
+++ b/recipe/linear_algebra/qr_decomposition.h
@@ -8,38 +8,6 @@ namespace linear_algebra {
 
 /// @brief
 ///
-/// `col_index` is 0 and `row_offset` is 2.
-///
-/// $$
-/// \left(
-///     \begin{array}{ccccc}
-///         a_{0}^{0}   & a_{1}^{0} & \cdots &        & a_{0}^{n-1}
-///         \\
-///         a_{0}^{1}   &           &        & \cdots & \vdots
-///         \\
-///         \vdots      &           &        & \ddots &
-///         \\
-///                     & \vdots    & \ddots & \ddots &
-///         \\
-///         a_{m-1}^{0} & \cdots    &        &        & a_{m-1}^{n-1}
-///     \end{array}
-/// \right)
-/// $$
-///
-/// $$
-/// v
-/// =
-/// \left(
-///     \begin{array}{c}
-///         a_{c_{0}}^{r_{0}}
-///         \\
-///         \vdots
-///         \\
-///         a_{c_{0}}^{r_{0} + }
-///     \end{array}
-/// \right)
-/// $$
-///
 /// @param mat_a
 /// @param row_size
 /// @param col_size

--- a/recipe/linear_algebra/qr_decomposition.h
+++ b/recipe/linear_algebra/qr_decomposition.h
@@ -6,13 +6,21 @@
 namespace recipe {
 namespace linear_algebra {
 
-/// @brief
+/// @brief Compute Householder QR decomposition.
+///  Matrix $A$ is overwritten by the algorithm.
+///  If you need matrix $Q$ and $R$, use
+///  @ref ConvertHouseholderQRToQ(
+///  const double*, const double*, const int, const int)
+/// "ConvertHouseholderQRToQ" and
+///  @ref ConvertHouseholderQRToR(
+///  const double*, const double*, const int, const int)
+/// "ConvertHouseholderQRToR".
 ///
-/// @param mat_a
+/// @param mat_a matrix $A$. $A$ is overwritten.
 /// @param row_size
 /// @param col_size
 ///
-/// @return
+/// @return A lit of Householder vectors used to compute $Q$.
 ///
 std::unique_ptr<double[]> ComputeHouseholderQR(double* mat_a,
                                                const int row_size,

--- a/recipe/linear_algebra/qr_decomposition.h
+++ b/recipe/linear_algebra/qr_decomposition.h
@@ -6,10 +6,10 @@
 namespace recipe {
 namespace linear_algebra {
 
-/// @brief 
+/// @brief
 ///
 /// `col_index` is 0 and `row_offset` is 2.
-/// 
+///
 /// $$
 /// \left(
 ///     \begin{array}{ccccc}
@@ -25,7 +25,7 @@ namespace linear_algebra {
 ///     \end{array}
 /// \right)
 /// $$
-/// 
+///
 /// $$
 /// v
 /// =
@@ -44,55 +44,51 @@ namespace linear_algebra {
 /// @param row_size
 /// @param col_size
 ///
-/// @return 
-/// 
-std::unique_ptr<double[]> ComputeHouseholderQR(
-    double* mat_a, const int row_size, const int col_size);
+/// @return
+///
+std::unique_ptr<double[]> ComputeHouseholderQR(double* mat_a,
+                                               const int row_size,
+                                               const int col_size);
 
-/// @brief Extract a orthonomal $Q$ and a upper triangular matrix $R$ from 
-/// the resutl of 
-/// @ref ComputeHouseholderQR(double*, const int, const int) "ComputeHouseholderQR".
+/// @brief Extract a orthonomal $Q$ and a upper triangular matrix $R$ from
+/// the resutl of
+/// @ref ComputeHouseholderQR(double*, const int, const int)
+/// "ComputeHouseholderQR".
 /// TODO: Currently, the function support `row_size >= col_size`.
 ///
-/// @param mat_qr the results of decomposing function. See `ComputeHouseholderQR`.
-/// @param householder_coeffs 
+/// @param mat_qr the results of decomposing function. See
+/// `ComputeHouseholderQR`.
+/// @param householder_coeffs
 /// @param row_size num of rows of `mat_qr`.
 /// @param col_size num of rows of `mat_qr`.
 ///
 /// @return
-/// 
-std::unique_ptr<double[]>
-ConvertHouseholderQRToQ(
-    const double* mat_qr,
-    const double* householder_coeffs,
-    const int row_size,
+///
+std::unique_ptr<double[]> ConvertHouseholderQRToQ(
+    const double* mat_qr, const double* householder_coeffs, const int row_size,
     const int col_size);
 
-std::unique_ptr<double[]>
-ConvertHouseholderQRToR(
-    const double* mat_qr,
-    const double* householder_coeffs,
-    const int row_size,
+std::unique_ptr<double[]> ConvertHouseholderQRToR(
+    const double* mat_qr, const double* householder_coeffs, const int row_size,
     const int col_size);
 
-/// @brief Extract a orthonomal $Q$ and a upper triangular matrix $R$ from 
-/// the resutl of 
-/// @ref ComputeHouseholderQR(double*, const int, const int) "ComputeHouseholderQR".
+/// @brief Extract a orthonomal $Q$ and a upper triangular matrix $R$ from
+/// the resutl of
+/// @ref ComputeHouseholderQR(double*, const int, const int)
+/// "ComputeHouseholderQR".
 /// TODO: Currently, the function support `row_size >= col_size`.
 ///
-/// @param mat_qr the results of decomposing function. See `ComputeHouseholderQR`.
-/// @param householder_coeffs 
+/// @param mat_qr the results of decomposing function. See
+/// `ComputeHouseholderQR`.
+/// @param householder_coeffs
 /// @param row_size num of rows of `mat_qr`.
 /// @param col_size num of rows of `mat_qr`.
 ///
 /// @return the first of the pair is $Q$. the second is `R`.
-/// 
-std::pair<std::unique_ptr<double[]>,std::unique_ptr<double[]>>
-ConvertHouseholderQRToQR(
-    const double* mat_qr,
-    const double* householder_coeffs,
-    const int row_size,
-    const int col_size);
+///
+std::pair<std::unique_ptr<double[]>, std::unique_ptr<double[]>>
+ConvertHouseholderQRToQR(const double* mat_qr, const double* householder_coeffs,
+                         const int row_size, const int col_size);
 
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/qr_decomposition.h
+++ b/recipe/linear_algebra/qr_decomposition.h
@@ -1,0 +1,98 @@
+#pragma once
+#include <vector>
+#include "recipe/linear_algebra/matrix.h"
+#include "recipe/linear_algebra/vector.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+/// @brief 
+///
+/// `col_index` is 0 and `row_offset` is 2.
+/// 
+/// $$
+/// \left(
+///     \begin{array}{ccccc}
+///         a_{0}^{0}   & a_{1}^{0} & \cdots &        & a_{0}^{n-1}
+///         \\
+///         a_{0}^{1}   &           &        & \cdots & \vdots
+///         \\
+///         \vdots      &           &        & \ddots &
+///         \\
+///                     & \vdots    & \ddots & \ddots &
+///         \\
+///         a_{m-1}^{0} & \cdots    &        &        & a_{m-1}^{n-1}
+///     \end{array}
+/// \right)
+/// $$
+/// 
+/// $$
+/// v
+/// =
+/// \left(
+///     \begin{array}{c}
+///         a_{c_{0}}^{r_{0}}
+///         \\
+///         \vdots
+///         \\
+///         a_{c_{0}}^{r_{0} + }
+///     \end{array}
+/// \right)
+/// $$
+///
+/// @param mat_a
+/// @param row_size
+/// @param col_size
+///
+/// @return 
+/// 
+std::unique_ptr<double[]> ComputeHouseholderQR(
+    double* mat_a, const int row_size, const int col_size);
+
+/// @brief Extract a orthonomal $Q$ and a upper triangular matrix $R$ from 
+/// the resutl of 
+/// @ref ComputeHouseholderQR(double*, const int, const int) "ComputeHouseholderQR".
+/// TODO: Currently, the function support `row_size >= col_size`.
+///
+/// @param mat_qr the results of decomposing function. See `ComputeHouseholderQR`.
+/// @param householder_coeffs 
+/// @param row_size num of rows of `mat_qr`.
+/// @param col_size num of rows of `mat_qr`.
+///
+/// @return
+/// 
+std::unique_ptr<double[]>
+ConvertHouseholderQRToQ(
+    const double* mat_qr,
+    const double* householder_coeffs,
+    const int row_size,
+    const int col_size);
+
+std::unique_ptr<double[]>
+ConvertHouseholderQRToR(
+    const double* mat_qr,
+    const double* householder_coeffs,
+    const int row_size,
+    const int col_size);
+
+/// @brief Extract a orthonomal $Q$ and a upper triangular matrix $R$ from 
+/// the resutl of 
+/// @ref ComputeHouseholderQR(double*, const int, const int) "ComputeHouseholderQR".
+/// TODO: Currently, the function support `row_size >= col_size`.
+///
+/// @param mat_qr the results of decomposing function. See `ComputeHouseholderQR`.
+/// @param householder_coeffs 
+/// @param row_size num of rows of `mat_qr`.
+/// @param col_size num of rows of `mat_qr`.
+///
+/// @return the first of the pair is $Q$. the second is `R`.
+/// 
+std::pair<std::unique_ptr<double[]>,std::unique_ptr<double[]>>
+ConvertHouseholderQRToQR(
+    const double* mat_qr,
+    const double* householder_coeffs,
+    const int row_size,
+    const int col_size);
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/qr_decomposition_test.cc
+++ b/recipe/linear_algebra/qr_decomposition_test.cc
@@ -1,9 +1,9 @@
 #include "recipe/linear_algebra/qr_decomposition.h"
 #include <gtest/gtest.h>
-#include "recipe/linear_algebra/test_util/test_data.h"
-#include "recipe/linear_algebra/test_util/gtest_assertion.h"
-#include "recipe/linear_algebra/operator_unary.h"
 #include "recipe/linear_algebra/operator_binary.h"
+#include "recipe/linear_algebra/operator_unary.h"
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include "recipe/linear_algebra/test_util/test_data.h"
 #include "recipe/linear_algebra/util.h"
 #include "recipe/test_util/test_util.h"
 
@@ -14,15 +14,14 @@ namespace linear_algebra {
 // ComputeHouseholderQR
 //
 TEST(ComputeHouseholderQRTest, Example0) {
-  std::unique_ptr<double[]> mat_a = MakeDoubleArray(
-      {
+  std::unique_ptr<double[]> mat_a = MakeDoubleArray({
       // clang-format off
         1, -1, 4,
         1, 4, -2,
         1, 4, 2,
         1, -1, 0,
       // clang-format on
-      });
+  });
   const int row_size = 4;
   const int col_size = 3;
   // v1 = (-1, 1, 1, 1) -> (1, -1, -1, -1)
@@ -35,38 +34,36 @@ TEST(ComputeHouseholderQRTest, Example0) {
   // 0, 0, 4,
   // 0, 0, 0
   // acutal is householder_vector
-  std::unique_ptr<double[]> householder_coeffs = ComputeHouseholderQR(
-      mat_a.get(), row_size, col_size);
+  std::unique_ptr<double[]> householder_coeffs =
+      ComputeHouseholderQR(mat_a.get(), row_size, col_size);
 
-  const std::unique_ptr<double[]> expect = MakeDoubleArray(
-      {
+  const std::unique_ptr<double[]> expect = MakeDoubleArray({
       // clang-format off
         2, 3, 2,
         -1, 5, -2,
         -1, 0, 4,
         -1, 1, 0,
       // clang-format on
-      });
+  });
   EXPECT_ARRAY_ELEMENT_EQ(expect, mat_a, row_size * col_size);
-  const std::unique_ptr<double[]> expect_householder_coeffs = MakeDoubleArray(
-      {
+  const std::unique_ptr<double[]> expect_householder_coeffs = MakeDoubleArray({
       // clang-format off
         0.5, 1.0, 0,
       // clang-format on
-      });
-  EXPECT_ARRAY_ELEMENT_EQ(expect_householder_coeffs, householder_coeffs, col_size);
+  });
+  EXPECT_ARRAY_ELEMENT_EQ(expect_householder_coeffs, householder_coeffs,
+                          col_size);
 }
 
 TEST(ComputeHouseholderQRTest, Assert) {
-  std::unique_ptr<double[]> mat_a = MakeDoubleArray(
-      {
+  std::unique_ptr<double[]> mat_a = MakeDoubleArray({
       // clang-format off
         1, -1, 4,
         1, 4, -2,
         1, 4, 2,
         1, -1, 0,
       // clang-format on
-      });
+  });
   const int row_size = 3;
   const int col_size = 4;
   // acutal is householder_vector
@@ -74,60 +71,56 @@ TEST(ComputeHouseholderQRTest, Assert) {
 }
 
 TEST(ConvertHouseholderQRToQTest, Example0) {
-  std::unique_ptr<double[]> mat_a = MakeDoubleArray(
-      {
+  std::unique_ptr<double[]> mat_a = MakeDoubleArray({
       // clang-format off
         1, -1, 4,
         1, 4, -2,
         1, 4, 2,
         1, -1, 0,
       // clang-format on
-      });
+  });
   const int row_size = 4;
   const int col_size = 3;
-  std::unique_ptr<double[]> householder_coeffs = ComputeHouseholderQR(
-      mat_a.get(), row_size, col_size);
+  std::unique_ptr<double[]> householder_coeffs =
+      ComputeHouseholderQR(mat_a.get(), row_size, col_size);
   // acutal is householder_vector
   std::unique_ptr<double[]> mat_q = ConvertHouseholderQRToQ(
       mat_a.get(), householder_coeffs.get(), row_size, col_size);
-  std::unique_ptr<double[]> expect = MakeDoubleArray(
-      {
+  std::unique_ptr<double[]> expect = MakeDoubleArray({
       // clang-format off
         0.5, -0.5, 0.5, -0.5,
         0.5, 0.5, -0.5, -0.5,
         0.5, 0.5, 0.5, 0.5,
         0.5, -0.5, -0.5, 0.5,
       // clang-format on
-      });
+  });
   EXPECT_ARRAY_ELEMENT_EQ(expect, mat_q, row_size * col_size);
 }
 
 TEST(ConvertHouseholderQRToRTest, Example0) {
-  std::unique_ptr<double[]> mat_a = MakeDoubleArray(
-      {
+  std::unique_ptr<double[]> mat_a = MakeDoubleArray({
       // clang-format off
         1, -1, 4,
         1, 4, -2,
         1, 4, 2,
         1, -1, 0,
       // clang-format on
-      });
+  });
   const int row_size = 4;
   const int col_size = 3;
-  std::unique_ptr<double[]> householder_coeffs = ComputeHouseholderQR(
-      mat_a.get(), row_size, col_size);
+  std::unique_ptr<double[]> householder_coeffs =
+      ComputeHouseholderQR(mat_a.get(), row_size, col_size);
   // acutal is householder_vector
   std::unique_ptr<double[]> mat_r = ConvertHouseholderQRToR(
       mat_a.get(), householder_coeffs.get(), row_size, col_size);
-  std::unique_ptr<double[]> expect = MakeDoubleArray(
-      {
+  std::unique_ptr<double[]> expect = MakeDoubleArray({
       // clang-format off
         2, 3, 2,
         0, 5, -2,
         0, 0, 4,
         0, 0, 0,
       // clang-format on
-      });
+  });
   EXPECT_ARRAY_ELEMENT_EQ(expect, mat_r, row_size * col_size);
 }
 

--- a/recipe/linear_algebra/qr_decomposition_test.cc
+++ b/recipe/linear_algebra/qr_decomposition_test.cc
@@ -55,6 +55,7 @@ TEST(ComputeHouseholderQRTest, Example0) {
                           col_size);
 }
 
+#ifndef NDEBUG
 TEST(ComputeHouseholderQRTest, Assert) {
   std::unique_ptr<double[]> mat_a = MakeDoubleArray({
       // clang-format off
@@ -69,6 +70,7 @@ TEST(ComputeHouseholderQRTest, Assert) {
   // acutal is householder_vector
   EXPECT_ASSERT_FAIL(ComputeHouseholderQR(mat_a.get(), row_size, col_size));
 }
+#endif
 
 TEST(ConvertHouseholderQRToQTest, Example0) {
   std::unique_ptr<double[]> mat_a = MakeDoubleArray({

--- a/recipe/linear_algebra/qr_decomposition_test.cc
+++ b/recipe/linear_algebra/qr_decomposition_test.cc
@@ -1,0 +1,139 @@
+#include "recipe/linear_algebra/qr_decomposition.h"
+#include <gtest/gtest.h>
+#include "recipe/linear_algebra/test_util/test_data.h"
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include "recipe/linear_algebra/operator_unary.h"
+#include "recipe/linear_algebra/operator_binary.h"
+#include "recipe/linear_algebra/util.h"
+#include "recipe/test_util/test_util.h"
+
+namespace recipe {
+namespace linear_algebra {
+
+//
+// ComputeHouseholderQR
+//
+TEST(ComputeHouseholderQRTest, Example0) {
+  std::unique_ptr<double[]> mat_a = MakeDoubleArray(
+      {
+      // clang-format off
+        1, -1, 4,
+        1, 4, -2,
+        1, 4, 2,
+        1, -1, 0,
+      // clang-format on
+      });
+  const int row_size = 4;
+  const int col_size = 3;
+  // v1 = (-1, 1, 1, 1) -> (1, -1, -1, -1)
+  // beta = 2 / sqrt(4)^{2} = 0.5
+  // v2 = (-5, 0, -5) -> (1, 0, 1)
+  // beta = 2 / sqrt(2)^{2} = 1.0
+  // R =
+  // 2, 3, 2
+  // 0, 5, -2,
+  // 0, 0, 4,
+  // 0, 0, 0
+  // acutal is householder_vector
+  std::unique_ptr<double[]> householder_coeffs = ComputeHouseholderQR(
+      mat_a.get(), row_size, col_size);
+
+  const std::unique_ptr<double[]> expect = MakeDoubleArray(
+      {
+      // clang-format off
+        2, 3, 2,
+        -1, 5, -2,
+        -1, 0, 4,
+        -1, 1, 0,
+      // clang-format on
+      });
+  EXPECT_ARRAY_ELEMENT_EQ(expect, mat_a, row_size * col_size);
+  const std::unique_ptr<double[]> expect_householder_coeffs = MakeDoubleArray(
+      {
+      // clang-format off
+        0.5, 1.0, 0,
+      // clang-format on
+      });
+  EXPECT_ARRAY_ELEMENT_EQ(expect_householder_coeffs, householder_coeffs, col_size);
+}
+
+TEST(ComputeHouseholderQRTest, Assert) {
+  std::unique_ptr<double[]> mat_a = MakeDoubleArray(
+      {
+      // clang-format off
+        1, -1, 4,
+        1, 4, -2,
+        1, 4, 2,
+        1, -1, 0,
+      // clang-format on
+      });
+  const int row_size = 3;
+  const int col_size = 4;
+  // acutal is householder_vector
+  EXPECT_ASSERT_FAIL(ComputeHouseholderQR(mat_a.get(), row_size, col_size));
+}
+
+TEST(ConvertHouseholderQRToQTest, Example0) {
+  std::unique_ptr<double[]> mat_a = MakeDoubleArray(
+      {
+      // clang-format off
+        1, -1, 4,
+        1, 4, -2,
+        1, 4, 2,
+        1, -1, 0,
+      // clang-format on
+      });
+  const int row_size = 4;
+  const int col_size = 3;
+  std::unique_ptr<double[]> householder_coeffs = ComputeHouseholderQR(
+      mat_a.get(), row_size, col_size);
+  // acutal is householder_vector
+  std::unique_ptr<double[]> mat_q = ConvertHouseholderQRToQ(
+      mat_a.get(), householder_coeffs.get(), row_size, col_size);
+  std::unique_ptr<double[]> expect = MakeDoubleArray(
+      {
+      // clang-format off
+        0.5, -0.5, 0.5, -0.5,
+        0.5, 0.5, -0.5, -0.5,
+        0.5, 0.5, 0.5, 0.5,
+        0.5, -0.5, -0.5, 0.5,
+      // clang-format on
+      });
+  EXPECT_ARRAY_ELEMENT_EQ(expect, mat_q, row_size * col_size);
+}
+
+TEST(ConvertHouseholderQRToRTest, Example0) {
+  std::unique_ptr<double[]> mat_a = MakeDoubleArray(
+      {
+      // clang-format off
+        1, -1, 4,
+        1, 4, -2,
+        1, 4, 2,
+        1, -1, 0,
+      // clang-format on
+      });
+  const int row_size = 4;
+  const int col_size = 3;
+  std::unique_ptr<double[]> householder_coeffs = ComputeHouseholderQR(
+      mat_a.get(), row_size, col_size);
+  // acutal is householder_vector
+  std::unique_ptr<double[]> mat_r = ConvertHouseholderQRToR(
+      mat_a.get(), householder_coeffs.get(), row_size, col_size);
+  std::unique_ptr<double[]> expect = MakeDoubleArray(
+      {
+      // clang-format off
+        2, 3, 2,
+        0, 5, -2,
+        0, 0, 4,
+        0, 0, 0,
+      // clang-format on
+      });
+  EXPECT_ARRAY_ELEMENT_EQ(expect, mat_r, row_size * col_size);
+}
+
+//
+// GivensQR
+//
+
+}  // namespace linear_algebra
+}  // namespace recipe

--- a/recipe/linear_algebra/test_util/gtest_assertion.h
+++ b/recipe/linear_algebra/test_util/gtest_assertion.h
@@ -5,14 +5,14 @@
 #include "recipe/linear_algebra/vector.h"
 #include "recipe/test_util/gtest_assertion.h"
 
-/// @brief 
-/// 
+/// @brief
+///
 #define EXPECT_MATRIX_ELEMENT_NEAR(expect, actual, abs_error)             \
   EXPECT_PRED_FORMAT3(recipe::linear_algebra::IsElementNearEqual, expect, \
                       actual, abs_error)
 
-/// @brief 
-/// 
+/// @brief
+///
 #define EXPECT_VECTOR_ELEMENT_NEAR(expect, actual, abs_error)             \
   EXPECT_PRED_FORMAT3(recipe::linear_algebra::IsElementNearEqual, expect, \
                       actual, abs_error)

--- a/recipe/linear_algebra/test_util/gtest_assertion.h
+++ b/recipe/linear_algebra/test_util/gtest_assertion.h
@@ -81,34 +81,5 @@ inline ::testing::AssertionResult IsElementNearEqual(
   }
   return ::testing::AssertionSuccess();
 }
-
-//
-// IsElementEqual
-//
-/*
-inline ::testing::AssertionResult IsElementEqual(
-    const char* expr1, const char* expr2,
-    const Vector& vec1, const Vector& vec2) {
-  if (vec1.Size() != vec2.Size()) {
-    return ::testing::AssertionFailure()
-           << "size is not the same." << std::endl
-           << "expect.Size: " << vec1.Size() << std::endl
-           << "actual.Size: " << vec2.Size();
-  }
-
-  for (size_t row = 0; row < vec1.Size(); ++row) {
-    const ::testing::internal::Double val1(vec1(row));
-    const ::testing::internal::Double val2(vec2(row));
-    if (!val1.AlmostEquals(val2)) {
-      return ::testing::AssertionFailure()
-             << expr1 << " and " << expr2 << " is not equal" << std::endl
-             << expr1 << "(" << row << ") evaluates to " << val1 << ","
-             << std::endl
-             << expr2 << "(" << row << ") evaluates to " << val2 << ".";
-    }
-  }
-  return ::testing::AssertionSuccess();
-}
-*/
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/linear_algebra/test_util/gtest_assertion.h
+++ b/recipe/linear_algebra/test_util/gtest_assertion.h
@@ -17,12 +17,6 @@
   EXPECT_PRED_FORMAT3(recipe::linear_algebra::IsElementNearEqual, expect, \
                       actual, abs_error)
 
-// @brief 
-//
-// #define EXPECT_VECTOR_ELEMENT_DOUBLE_EQ(expect, actual)                   \
-//  EXPECT_PRED_FORMAT2(recipe::linear_algebra::IsElementEqual, expect, \
-//                      actual)
-
 namespace recipe {
 namespace linear_algebra {
 //

--- a/recipe/linear_algebra/test_util/gtest_assertion.h
+++ b/recipe/linear_algebra/test_util/gtest_assertion.h
@@ -5,16 +5,29 @@
 #include "recipe/linear_algebra/vector.h"
 #include "recipe/test_util/gtest_assertion.h"
 
+/// @brief 
+/// 
 #define EXPECT_MATRIX_ELEMENT_NEAR(expect, actual, abs_error)             \
   EXPECT_PRED_FORMAT3(recipe::linear_algebra::IsElementNearEqual, expect, \
                       actual, abs_error)
 
+/// @brief 
+/// 
 #define EXPECT_VECTOR_ELEMENT_NEAR(expect, actual, abs_error)             \
   EXPECT_PRED_FORMAT3(recipe::linear_algebra::IsElementNearEqual, expect, \
                       actual, abs_error)
 
+// @brief 
+//
+// #define EXPECT_VECTOR_ELEMENT_DOUBLE_EQ(expect, actual)                   \
+//  EXPECT_PRED_FORMAT2(recipe::linear_algebra::IsElementEqual, expect, \
+//                      actual)
+
 namespace recipe {
 namespace linear_algebra {
+//
+// IsElementNearEqual
+//
 inline ::testing::AssertionResult IsElementNearEqual(
     const char* expr1, const char* expr2, const char* abs_error_expr,
     const Matrix& mat1, const Matrix& mat2, const double abs_error) {
@@ -75,5 +88,33 @@ inline ::testing::AssertionResult IsElementNearEqual(
   return ::testing::AssertionSuccess();
 }
 
+//
+// IsElementEqual
+//
+/*
+inline ::testing::AssertionResult IsElementEqual(
+    const char* expr1, const char* expr2,
+    const Vector& vec1, const Vector& vec2) {
+  if (vec1.Size() != vec2.Size()) {
+    return ::testing::AssertionFailure()
+           << "size is not the same." << std::endl
+           << "expect.Size: " << vec1.Size() << std::endl
+           << "actual.Size: " << vec2.Size();
+  }
+
+  for (size_t row = 0; row < vec1.Size(); ++row) {
+    const ::testing::internal::Double val1(vec1(row));
+    const ::testing::internal::Double val2(vec2(row));
+    if (!val1.AlmostEquals(val2)) {
+      return ::testing::AssertionFailure()
+             << expr1 << " and " << expr2 << " is not equal" << std::endl
+             << expr1 << "(" << row << ") evaluates to " << val1 << ","
+             << std::endl
+             << expr2 << "(" << row << ") evaluates to " << val2 << ".";
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+*/
 }  // namespace linear_algebra
 }  // namespace recipe

--- a/recipe/test_util/gtest_assertion.h
+++ b/recipe/test_util/gtest_assertion.h
@@ -45,6 +45,10 @@
 
 namespace recipe {
 namespace test_util {
+
+//
+// Compare two vectors
+//
 template <typename T>
 inline ::testing::AssertionResult IsElementEqual(const std::vector<T>& v1,
                                                  const std::vector<T>& v2) {
@@ -83,9 +87,12 @@ inline ::testing::AssertionResult IsElementEqual(
   return ::testing::AssertionSuccess();
 }
 
+//
+// Compare two double pointers with size.
+// 
 inline ::testing::AssertionResult IsElementEqual(
     const char* expr1, const char* expr2, const char* size_expr,
-    const std::unique_ptr<double[]>& v1, const std::unique_ptr<double[]>& v2,
+    const double* v1, const double* v2,
     const int size) {
   for (size_t i = 0; i < size; ++i) {
     const ::testing::internal::FloatingPoint<double> value1(v1[i]);
@@ -98,6 +105,27 @@ inline ::testing::AssertionResult IsElementEqual(
     }
   }
   return ::testing::AssertionSuccess();
+}
+
+inline ::testing::AssertionResult IsElementEqual(
+    const char* expr1, const char* expr2, const char* size_expr,
+    const double* v1, const std::unique_ptr<double[]>& v2,
+    const int size) {
+  return IsElementEqual(expr1, expr2, size_expr, v1, v2.get(), size);
+}
+
+inline ::testing::AssertionResult IsElementEqual(
+    const char* expr1, const char* expr2, const char* size_expr,
+    const std::unique_ptr<double[]>& v1, const double* v2,
+    const int size) {
+  return IsElementEqual(expr1, expr2, size_expr, v1.get(), v2, size);
+}
+
+inline ::testing::AssertionResult IsElementEqual(
+    const char* expr1, const char* expr2, const char* size_expr,
+    const std::unique_ptr<double[]>& v1, const std::unique_ptr<double[]>& v2,
+    const int size) {
+  return IsElementEqual(expr1, expr2, size_expr, v1.get(), v2.get(), size);
 }
 
 }  // namespace test_util

--- a/recipe/test_util/gtest_assertion.h
+++ b/recipe/test_util/gtest_assertion.h
@@ -3,13 +3,43 @@
 #include <memory>
 #include <vector>
 
+/// @brief an assertion compares two vectors.
+/// Two vectors must have the same values.
+/// 
+/// Example
+/// =======
+/// 
+/// ```
+///   std::vector<double> expect(5, 1);
+///   std::vector<double> actual(5, 1);
+///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual);
+/// ```
 #define EXPECT_VECTOR_ELEMENT_EQ(expect, actual) \
   EXPECT_TRUE(recipe::test_util::IsElementEqual(expect, actual));
 
-#define EXPECT_VECTOR_ELEMENT_EQ_WITH_INDEX(expect, actual, index) \
-  EXPECT_TRUE(recipe::test_util::IsElementEqual(expect, actual))   \
-      << "failed at " << index;
-
+/// @brief an assertion compares two arrays.
+/// Two arrays must have the same values of the elements.
+/// 
+/// Example
+/// =======
+/// 
+/// ```
+///   std::unique_ptr<double[]> expect(new double[5]);
+///   std::unique_ptr<double[]> actual(new double[5]);
+///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, 5);
+///   
+///   double expect[] = {1, 2, 3};
+///   double actual[] = {1, 2, 3};
+///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, 3);
+///   
+///   double expect[] = {1, 2, 3};
+///   std::unique_ptr<double[]> actual(new double[3]);
+///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, 3);
+///   
+///   std::unique_ptr<double[]> expect(new double[3]);
+///   double actual[] = {1, 2, 3};
+///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, 3);
+/// ```
 #define EXPECT_ARRAY_ELEMENT_EQ(expect, actual, size) \
   EXPECT_PRED_FORMAT3(recipe::test_util::IsElementEqual, expect, actual, size)
 

--- a/recipe/test_util/gtest_assertion.h
+++ b/recipe/test_util/gtest_assertion.h
@@ -1,15 +1,15 @@
 #pragma once
 #include <gtest/gtest.h>
+#include <cmath>
 #include <memory>
 #include <vector>
-#include <cmath>
 
 /// @brief an assertion compares two vectors.
 /// Two vectors must have the same values.
-/// 
+///
 /// Example
 /// =======
-/// 
+///
 /// ```
 ///   std::vector<double> expect(5, 1);
 ///   std::vector<double> actual(5, 1);
@@ -20,23 +20,23 @@
 
 /// @brief an assertion compares two arrays.
 /// Two arrays must have the same values of the elements.
-/// 
+///
 /// Example
 /// =======
-/// 
+///
 /// ```
 ///   std::unique_ptr<double[]> expect(new double[5]);
 ///   std::unique_ptr<double[]> actual(new double[5]);
 ///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, 5);
-///   
+///
 ///   double expect[] = {1, 2, 3};
 ///   double actual[] = {1, 2, 3};
 ///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, 3);
-///   
+///
 ///   double expect[] = {1, 2, 3};
 ///   std::unique_ptr<double[]> actual(new double[3]);
 ///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, 3);
-///   
+///
 ///   std::unique_ptr<double[]> expect(new double[3]);
 ///   double actual[] = {1, 2, 3};
 ///   EXPECT_ARRAY_ELEMENT_EQ(expect, actual, 3);
@@ -46,30 +46,30 @@
 
 /// @brief an assertion compares two arrays.
 /// Two arrays must have the same values of the elements.
-/// 
+///
 /// Example
 /// =======
-/// 
+///
 /// ```
 ///   double expect[] = {1, 2, 3};
 ///   double actual[] = {1, 2, 3};
 ///   EXPECT_ARRAY_ELEMENT_NEAR(expect, actual, 3, 1e-10);
 /// ```
-#define EXPECT_ARRAY_ELEMENT_NEAR(expect, actual, size, abs_error) \
-  EXPECT_PRED_FORMAT4(recipe::test_util::IsElementNearEqual, expect, actual, size, abs_error)
+#define EXPECT_ARRAY_ELEMENT_NEAR(expect, actual, size, abs_error)           \
+  EXPECT_PRED_FORMAT4(recipe::test_util::IsElementNearEqual, expect, actual, \
+                      size, abs_error)
 
 /// @brief an assertion checkes whether the statement passes.
 /// The message of `assert` function varies between compilers.
 ///
 /// Example
 /// =======
-/// 
+///
 /// ```
 ///   EXPECT_ASSERT_FAIL(assert(1 != 1)); // Pass
 ///   EXPECT_ASSERT_FAIL(assert(1 == 1)); // Fail
 /// ```
-#define EXPECT_ASSERT_FAIL(statement) \
-  EXPECT_DEATH(statement, "Assert")
+#define EXPECT_ASSERT_FAIL(statement) EXPECT_DEATH(statement, "Assert")
 
 namespace recipe {
 namespace test_util {
@@ -117,11 +117,10 @@ inline ::testing::AssertionResult IsElementEqual(
 
 //
 // Compare two double pointers with size.
-// 
+//
 inline ::testing::AssertionResult IsElementEqual(
     const char* expr1, const char* expr2, const char* size_expr,
-    const double* v1, const double* v2,
-    const int size) {
+    const double* v1, const double* v2, const int size) {
   for (size_t i = 0; i < size; ++i) {
     const ::testing::internal::FloatingPoint<double> value1(v1[i]);
     const ::testing::internal::FloatingPoint<double> value2(v2[i]);
@@ -137,15 +136,13 @@ inline ::testing::AssertionResult IsElementEqual(
 
 inline ::testing::AssertionResult IsElementEqual(
     const char* expr1, const char* expr2, const char* size_expr,
-    const double* v1, const std::unique_ptr<double[]>& v2,
-    const int size) {
+    const double* v1, const std::unique_ptr<double[]>& v2, const int size) {
   return IsElementEqual(expr1, expr2, size_expr, v1, v2.get(), size);
 }
 
 inline ::testing::AssertionResult IsElementEqual(
     const char* expr1, const char* expr2, const char* size_expr,
-    const std::unique_ptr<double[]>& v1, const double* v2,
-    const int size) {
+    const std::unique_ptr<double[]>& v1, const double* v2, const int size) {
   return IsElementEqual(expr1, expr2, size_expr, v1.get(), v2, size);
 }
 
@@ -161,15 +158,16 @@ inline ::testing::AssertionResult IsElementEqual(
 //
 
 inline ::testing::AssertionResult IsElementNearEqual(
-    const char* expr1, const char* expr2, const char* size_expr, const char* abs_error_expr,
-    const double* vec1, const double* vec2, const int size, const double abs_error) {
+    const char* expr1, const char* expr2, const char* size_expr,
+    const char* abs_error_expr, const double* vec1, const double* vec2,
+    const int size, const double abs_error) {
   for (int i = 0; i < size; ++i) {
     const double diff = std::fabs(vec1[i] - vec2[i]);
     if (diff > abs_error) {
       return ::testing::AssertionFailure()
-             << "The difference between " << expr1 << " and " << expr2
-             << " at " << i << "-th index is " << diff
-             << ", which exceeds " << abs_error_expr << ", where\n"
+             << "The difference between " << expr1 << " and " << expr2 << " at "
+             << i << "-th index is " << diff << ", which exceeds "
+             << abs_error_expr << ", where\n"
              << expr1 << " evaluates to " << vec1[i] << ",\n"
              << expr2 << " evaluates to " << vec2[i] << ", and\n"
              << abs_error_expr << " evaluates to " << abs_error << ".";
@@ -179,24 +177,29 @@ inline ::testing::AssertionResult IsElementNearEqual(
 }
 
 inline ::testing::AssertionResult IsElementNearEqual(
-    const char* expr1, const char* expr2, const char* size_expr, const char* abs_error_expr,
-    const std::unique_ptr<double[]>& vec1, const double* vec2, const int size, const double abs_error) {
-  return IsElementNearEqual(
-      expr1, expr2, size_expr, abs_error_expr, vec1.get(), vec2, size, abs_error);
+    const char* expr1, const char* expr2, const char* size_expr,
+    const char* abs_error_expr, const std::unique_ptr<double[]>& vec1,
+    const double* vec2, const int size, const double abs_error) {
+  return IsElementNearEqual(expr1, expr2, size_expr, abs_error_expr, vec1.get(),
+                            vec2, size, abs_error);
 }
 
 inline ::testing::AssertionResult IsElementNearEqual(
-    const char* expr1, const char* expr2, const char* size_expr, const char* abs_error_expr,
-    const double* vec1, const std::unique_ptr<double[]>& vec2, const int size, const double abs_error) {
-  return IsElementNearEqual(
-      expr1, expr2, size_expr, abs_error_expr, vec1, vec2.get(), size, abs_error);
+    const char* expr1, const char* expr2, const char* size_expr,
+    const char* abs_error_expr, const double* vec1,
+    const std::unique_ptr<double[]>& vec2, const int size,
+    const double abs_error) {
+  return IsElementNearEqual(expr1, expr2, size_expr, abs_error_expr, vec1,
+                            vec2.get(), size, abs_error);
 }
 
 inline ::testing::AssertionResult IsElementNearEqual(
-    const char* expr1, const char* expr2, const char* size_expr, const char* abs_error_expr,
-    const std::unique_ptr<double[]>& vec1, const std::unique_ptr<double[]>& vec2, const int size, const double abs_error) {
-  return IsElementNearEqual(
-      expr1, expr2, size_expr, abs_error_expr, vec1.get(), vec2.get(), size, abs_error);
+    const char* expr1, const char* expr2, const char* size_expr,
+    const char* abs_error_expr, const std::unique_ptr<double[]>& vec1,
+    const std::unique_ptr<double[]>& vec2, const int size,
+    const double abs_error) {
+  return IsElementNearEqual(expr1, expr2, size_expr, abs_error_expr, vec1.get(),
+                            vec2.get(), size, abs_error);
 }
 
 }  // namespace test_util

--- a/recipe/test_util/test_util.h
+++ b/recipe/test_util/test_util.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#include "recipe/test_util/gtest_assersion.h"
+#include "recipe/test_util/gtest_assertion.h"
 #include "recipe/test_util/test_data.h"


### PR DESCRIPTION
## Summary
This PR implements Householder QR decomposition and some algorithms related to QR decomposition such as Householder Transformations and Givens Rotations.
The implemented algorithm does not support column pivoting, so a matrix passed by the algorithm must be full rank.
Besides, the algorithm only works in case of `num row >= num col`.

## TODO
* Support column pivoting
* Support `num row < num col`
* Implement other QR algorithms (e.g. Householer QR with column pivoting)

## Other comments
I fixed #15 in the commit 9ac685a.

## Reference
Details of implemeted algorithms are described in the following links.
* [Householder Transformation](http://i05nagai.github.io/memorandum/math/matrix/householder_transformation.html)
* [Givens Rotation](http://i05nagai.github.io/memorandum/math/matrix/givens_rotation.html)
* [QR decomposition](http://i05nagai.github.io/memorandum/math/matrix/qr_decomposition.html)
