### PR TITLE
Fix formatter issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,9 @@ matrix:
 install:
 - ci/travis/install.sh
 script:
-- ci/build/check_sanity.sh
+  # behavior of clang-formatter depends on the version of clang. In OSX, it's hard to install specified version. We only checks files on Linux
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then ci/build/check_sanity.sh; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then ci/build/check_sanity.sh --skip-clang-format; fi
 - ci/build/build.sh
 after_success:
 - ci/travis/after_success.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,10 @@ diff <my_cc_file> /tmp/my_cc_file.cc
 To format all of code in the repository, you can run the script on the root of the repository by executing the command:
 
 ```
-./tools/formatter.sh
+# Build docker images for formatter. Behaviour of formatter depends on the version of formatter.
+./tools/docker/gcc/docker_build_ubuntu1604.sh
+# Run formatter with docker images
+./tools/docker_run_formatter.sh
 ```
 
 ### bazel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,7 @@ There is no visualization of the result of the test coverage for now.
 * [x] lint
     * [x] C++ format check
         * [ClangFormat — Clang 8 documentation](https://clang.llvm.org/docs/ClangFormat.html)
+        * Using clnag-fromat version 5.0
     * [x] bazel format check
         * [buildtools/buildifier at master · bazelbuild/buildtools](https://github.com/bazelbuild/buildtools/tree/master/buildifier)
 * build with cmake

--- a/ci/_lib/install_bazel.sh
+++ b/ci/_lib/install_bazel.sh
@@ -58,7 +58,6 @@ install_bazel_osx()
     brew update
   fi
 
-  brew uninstall bazel
   # tap and install
   brew tap bazelbuild/tap
   brew tap-pin bazelbuild/tap

--- a/ci/_lib/install_bazel.sh
+++ b/ci/_lib/install_bazel.sh
@@ -58,7 +58,9 @@ install_bazel_osx()
     brew update
   fi
 
-  brew cask install homebrew/cask-versions/java8
-  brew install \
-    bazel
+  brew uninstall bazel
+  # tap and install
+  brew tap bazelbuild/tap
+  brew tap-pin bazelbuild/tap
+  brew install bazel
 }

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -26,22 +26,22 @@ install_buildifier_linux()
   #
   # install golang
   #
-  export GOPATH="/opt/local/golang"
-  export PATH="$PATH:/usr/lib/go-1.10/bin:$GOPATH/bin"
-  echo 'export GOPATH="'$GOPATH'"' | ${SUDO} tee -a ${HOME}/.bashrc
-  echo 'export PATH="'$PATH'"' | ${SUDO} tee -a ${HOME}/.bashrc
+  # export GOPATH="/opt/local/golang"
+  # export PATH="$PATH:/usr/lib/go-1.10/bin:$GOPATH/bin"
+  # echo 'export GOPATH="'$GOPATH'"' | ${SUDO} tee -a ${HOME}/.bashrc
+  # echo 'export PATH="'$PATH'"' | ${SUDO} tee -a ${HOME}/.bashrc
 
-  ${SUDO} apt-get install -y \
-    software-properties-common \
-    curl
-  ${SUDO} mkdir -p \
-      $GOPATH/bin
-  ${SUDO} add-apt-repository ppa:gophers/archive < /dev/null
-  ${SUDO} apt-get update
-  ${SUDO} apt-get install -y \
-        git \
-        golang-1.10-go
-  ${SUDO} GOPATH="$GOPATH" PATH="$PATH" /usr/lib/go-1.10/bin/go get github.com/bazelbuild/buildtools/buildifier
+  # ${SUDO} apt-get install -y \
+  #   software-properties-common \
+  #   curl
+  # ${SUDO} mkdir -p \
+  #     $GOPATH/bin
+  # ${SUDO} add-apt-repository ppa:gophers/archive < /dev/null
+  # ${SUDO} apt-get update
+  # ${SUDO} GOPATH="$GOPATH" PATH="$PATH" apt-get install -y \
+  #       git \
+  #       golang-1.10-go
+  # ${SUDO} GOPATH="$GOPATH" PATH="$PATH" /usr/lib/go-1.10/bin/go get github.com/bazelbuild/buildtools/buildifier
 }
 
 #

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -41,7 +41,7 @@ install_buildifier_linux()
   ${SUDO} apt-get install -y \
         git \
         golang-1.10-go
-  go get github.com/bazelbuild/buildtools/buildifier
+  ${SUDO} go get github.com/bazelbuild/buildtools/buildifier
 }
 
 #

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -41,7 +41,7 @@ install_buildifier_linux()
   ${SUDO} apt-get install -y \
         git \
         golang-1.10-go
-  ${SUDO} go get github.com/bazelbuild/buildtools/buildifier
+  ${SUDO} /usr/lib/go-1.10/bin/go get github.com/bazelbuild/buildtools/buildifier
 }
 
 #

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -36,10 +36,9 @@ install_buildifier_linux()
     curl
   ${SUDO} mkdir -p \
       $GOPATH/bin
-  ${SUDO} add-apt-repository ppa:gophers/archive
+  ${SUDO} add-apt-repository ppa:gophers/archive < /dev/null
   ${SUDO} apt-get update
   ${SUDO} apt-get install -y \
-        curl \
         git \
         golang-1.10-go
   go get github.com/bazelbuild/buildtools/buildifier

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -44,7 +44,7 @@ install_buildifier_linux()
         git \
         golang-1.10-go
   # go dep
-  ${SUDO} curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  ${SUDO} curl https://raw.githubusercontent.com/golang/dep/master/install.sh | ${SUDO} sh
 
   ${SUDO} go get github.com/bazelbuild/buildtools/buildifier
 }

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -35,18 +35,14 @@ install_buildifier_linux()
     software-properties-common \
     curl
   ${SUDO} mkdir -p \
-      $GOPATH \
-      $GOPATH/bin \
+      $GOPATH/bin
   ${SUDO} add-apt-repository ppa:gophers/archive
   ${SUDO} apt-get update
   ${SUDO} apt-get install -y \
         curl \
         git \
         golang-1.10-go
-  # go dep
-  ${SUDO} curl https://raw.githubusercontent.com/golang/dep/master/install.sh | ${SUDO} sh
-
-  ${SUDO} go get github.com/bazelbuild/buildtools/buildifier
+  go get github.com/bazelbuild/buildtools/buildifier
 }
 
 #

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+#
+# install_buildifier.sh
+#
+# variables:
+#   * _do_update=1
+#   * _use_sudo=1
+#
+install_bazel_linux()
+{
+
+  if [[ ${_use_sudo} -eq 1 ]]; then
+    local SUDO="sudo"
+  fi
+
+  if [[ ${_do_update} -eq 1 ]]; then
+    ${SUDO} apt-get update
+  fi
+
+  #
+  # install golang
+  #
+  export GOPATH="/opt/local/golang"
+  export PATH="$PATH:/usr/lib/go-1.10/bin:$GOPATH/bin"
+  echo 'export GOPATH="'$GOPATH'"' | ${SUDO} tee -a ${HOME}/.bashrc
+  echo 'export PATH="'$PATH'"' | ${SUDO} tee -a ${HOME}/.bashrc
+
+  ${SUDO} apt-get install -y \
+    software-properties-common \
+    curl
+  ${SUDO} mkdir -p \
+      $GOPATH \
+      $GOPATH/bin \
+  ${SUDO} add-apt-repository ppa:gophers/archive
+  ${SUDO} apt-get update
+  ${SUDO} apt-get install -y \
+        curl \
+        git \
+        golang-1.10-go
+  # go dep
+  ${SUDO} curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+  ${SUDO} go get github.com/bazelbuild/buildtools/buildifier
+}
+
+#
+# variables:
+#   * _do_update=1
+#
+install_bazel_osx()
+{
+  if [[ ${_do_update} -eq 1 ]]; then
+    brew update
+  fi
+
+  brew install buildifier
+}

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -41,7 +41,7 @@ install_buildifier_linux()
   ${SUDO} apt-get install -y \
         git \
         golang-1.10-go
-  ${SUDO} /usr/lib/go-1.10/bin/go get github.com/bazelbuild/buildtools/buildifier
+  ${SUDO} GOPATH="$GOPATH" PATH="$PATH" /usr/lib/go-1.10/bin/go get github.com/bazelbuild/buildtools/buildifier
 }
 
 #

--- a/ci/_lib/install_buildifier.sh
+++ b/ci/_lib/install_buildifier.sh
@@ -12,7 +12,7 @@ fi
 #   * _do_update=1
 #   * _use_sudo=1
 #
-install_bazel_linux()
+install_buildifier_linux()
 {
 
   if [[ ${_use_sudo} -eq 1 ]]; then
@@ -53,7 +53,7 @@ install_bazel_linux()
 # variables:
 #   * _do_update=1
 #
-install_bazel_osx()
+install_buildifier_osx()
 {
   if [[ ${_do_update} -eq 1 ]]; then
     brew update

--- a/ci/_lib/install_clang_format.sh
+++ b/ci/_lib/install_clang_format.sh
@@ -28,6 +28,7 @@ install_clang_format_linux()
   else
     ${SUDO} apt-get install -y clang-format
   fi
+  clang-format --version
 }
 
 #

--- a/ci/_lib/install_clang_format.sh
+++ b/ci/_lib/install_clang_format.sh
@@ -24,9 +24,11 @@ install_clang_format_linux()
 
   UBUNTU_VERSION=`get_ubuntu_version`
   if [[ "$UBUNTU_VERSION" == "14.04" ]]; then
-    ${SUDO} apt-get install -y clang-format-3.9
+    ${SUDO} apt-get install -y clang-format-5.0
+    ${SUDO} ln -f -s /usr/bin/clang-format-5.0 /usr/bin/clang-format
   else
-    ${SUDO} apt-get install -y clang-format
+    ${SUDO} apt-get install -y clang-format-5.0
+    ${SUDO} ln -f -s /usr/bin/clang-format-5.0 /usr/bin/clang-format
   fi
   clang-format --version
 }

--- a/ci/_lib/install_clang_format.sh
+++ b/ci/_lib/install_clang_format.sh
@@ -26,7 +26,7 @@ install_clang_format_linux()
   if [[ "$UBUNTU_VERSION" == "14.04" ]]; then
     # to install newer version
     ${SUDO} apt-get install -y software-properties-common
-    ${SUDO} apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main"
+    ${SUDO} apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
     ${SUDO} apt-get update
 
     ${SUDO} apt-get install -y clang-format-5.0

--- a/ci/_lib/install_clang_format.sh
+++ b/ci/_lib/install_clang_format.sh
@@ -29,7 +29,7 @@ install_clang_format_linux()
     ${SUDO} apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
     ${SUDO} apt-get update
 
-    ${SUDO} apt-get install -y clang-format-5.0
+    ${SUDO} apt-get install -y --allow-unauthenticated clang-format-5.0
     ${SUDO} ln -f -s /usr/bin/clang-format-5.0 /usr/bin/clang-format
   else
     ${SUDO} apt-get install -y clang-format-5.0

--- a/ci/_lib/install_clang_format.sh
+++ b/ci/_lib/install_clang_format.sh
@@ -24,6 +24,11 @@ install_clang_format_linux()
 
   UBUNTU_VERSION=`get_ubuntu_version`
   if [[ "$UBUNTU_VERSION" == "14.04" ]]; then
+    # to install newer version
+    ${SUDO} apt-get install -y software-properties-common
+    ${SUDO} apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main"
+    ${SUDO} apt-get update
+
     ${SUDO} apt-get install -y clang-format-5.0
     ${SUDO} ln -f -s /usr/bin/clang-format-5.0 /usr/bin/clang-format
   else

--- a/ci/build/build.sh
+++ b/ci/build/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+cat /etc/group
+cat /etc/passwd
+id
+
 set -e
 if [ ! -z "${RECIPE_DEBUG}" ]; then
   set -x

--- a/ci/linux/install_buildifier.sh
+++ b/ci/linux/install_buildifier.sh
@@ -8,4 +8,4 @@ fi
 PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
 source ${PATH_TO_CI}/_lib/install_buildifier.sh
 
-_use_sudo=${_use_sudo} _do_update=${_do_update} install_bazel_linux
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_buildifier_linux

--- a/ci/linux/install_buildifier.sh
+++ b/ci/linux/install_buildifier.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/install_buildifier.sh
+
+_use_sudo=${_use_sudo} _do_update=${_do_update} install_bazel_linux

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -24,6 +24,7 @@ fi
 # sourcing is required to export some variables
 #
 source ${PATH_TO_ROOT}/ci/travis/install_bazel.sh
+source ${PATH_TO_ROOT}/ci/travis/install_buildifier.sh
 source ${PATH_TO_ROOT}/ci/travis/install_clang_format.sh
 source ${PATH_TO_ROOT}/ci/travis/install_gcc.sh
 # ${PATH_TO_ROOT}/ci/travis/install_valgrind.sh

--- a/ci/travis/install_buildifier.sh
+++ b/ci/travis/install_buildifier.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+if [[ ! -z ${RECIPE_DEBUG+x} ]]; then
+  set -x
+fi
+
+PATH_TO_CI=$(cd $(dirname ${0});cd ..;pwd)
+source ${PATH_TO_CI}/_lib/install_buildifier.sh
+
+if [[ "$TRAVIS_OS_NAME" == "" ]]; then
+  echo "\$TRAVIS_OS_NAME is not set."
+  exit 1
+fi
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  _use_sudo=1 install_buildifier_linux
+fi
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  install_buildifier_osx
+fi

--- a/recipe/linear_algebra/vector_test.cc
+++ b/recipe/linear_algebra/vector_test.cc
@@ -1,9 +1,9 @@
 #include "recipe/linear_algebra/vector.h"
 #include <gtest/gtest.h>
-#include <sstream>
-#include "recipe/linear_algebra/test_util/test_data.h"
-#include "recipe/linear_algebra/test_util/gtest_assertion.h"
 #include <limits>
+#include <sstream>
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include "recipe/linear_algebra/test_util/test_data.h"
 
 namespace recipe {
 namespace linear_algebra {
@@ -15,7 +15,8 @@ TEST(VectorTest, CopyConstructor) {
   Vector expect(3);
   Vector actual(expect);
 
-  EXPECT_VECTOR_ELEMENT_NEAR(expect, actual, std::numeric_limits<double>::epsilon());
+  EXPECT_VECTOR_ELEMENT_NEAR(expect, actual,
+                             std::numeric_limits<double>::epsilon());
 }
 
 TEST(VectorTest, ConstructorInitializer) {

--- a/recipe/linear_algebra/vector_test.cc
+++ b/recipe/linear_algebra/vector_test.cc
@@ -2,6 +2,8 @@
 #include <gtest/gtest.h>
 #include <sstream>
 #include "recipe/linear_algebra/test_util/test_data.h"
+#include "recipe/linear_algebra/test_util/gtest_assertion.h"
+#include <limits>
 
 namespace recipe {
 namespace linear_algebra {
@@ -13,7 +15,7 @@ TEST(VectorTest, CopyConstructor) {
   Vector expect(3);
   Vector actual(expect);
 
-  EXPECT_EQ(expect, actual);
+  EXPECT_VECTOR_ELEMENT_NEAR(expect, actual, std::numeric_limits<double>::epsilon());
 }
 
 TEST(VectorTest, ConstructorInitializer) {

--- a/tools/docker/gcc/README.md
+++ b/tools/docker/gcc/README.md
@@ -2,11 +2,11 @@
 Build docker images with the command
 
 ```
-./docker_build.sh
+./docker_build_ubuntu1604.sh
 ```
 
 Run docker container and attach to it
 
 ```
-./docker_run.sh
+./docker_run_ubuntu1604.sh
 ```

--- a/tools/docker/gcc/docker_run_ubuntu1404.sh
+++ b/tools/docker/gcc/docker_run_ubuntu1404.sh
@@ -2,10 +2,16 @@
 
 PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../../..;pwd)
 
+# if no arguments are provided
+args=$@
+if [[ -z "${args}" ]]; then
+  args=/bin/bash
+fi
+
 docker run \
     --rm \
     -it \
     --volume ${PATH_TO_REPOSITORY}:/tmp/repository \
     --workdir /tmp/repository \
     recipe/gcc:4.9 \
-    /bin/bash
+    $args

--- a/tools/docker/gcc/docker_run_ubuntu1604.sh
+++ b/tools/docker/gcc/docker_run_ubuntu1604.sh
@@ -2,10 +2,16 @@
 
 PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ../../..;pwd)
 
+# if no arguments are provided
+args=$@
+if [[ -z "${args}" ]]; then
+  args=/bin/bash
+fi
+
 docker run \
     --rm \
     -it \
     --volume ${PATH_TO_REPOSITORY}:/tmp/repository \
     --workdir /tmp/repository \
     recipe/gcc:4.9 \
-    /bin/bash
+    $args

--- a/tools/docker/gcc/ubuntu1404/Dockerfile
+++ b/tools/docker/gcc/ubuntu1404/Dockerfile
@@ -8,6 +8,7 @@ COPY ci /tmp/ci
 RUN \
     apt-get update \
     && /tmp/ci/linux/install_bazel.sh \
+    && /tmp/ci/linux/install_buildifier.sh \
     && /tmp/ci/linux/install_clang_format.sh \
     && /tmp/ci/linux/install_gcc.sh \
     && rm -rf /var/lib/apt/lists/* \

--- a/tools/docker/gcc/ubuntu1604/Dockerfile
+++ b/tools/docker/gcc/ubuntu1604/Dockerfile
@@ -8,6 +8,7 @@ COPY ci /tmp/ci
 RUN \
     apt-get update \
     && /tmp/ci/linux/install_bazel.sh \
+    && /tmp/ci/linux/install_buildifier.sh \
     && /tmp/ci/linux/install_clang_format.sh \
     && /tmp/ci/linux/install_gcc.sh \
     && rm -rf /var/lib/apt/lists/* \

--- a/tools/docker_run_formatter.sh
+++ b/tools/docker_run_formatter.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+PATH_TO_REPOSITORY=$(cd $(dirname ${0});cd ..;pwd)
+cd $PATH_TO_REPOSITORY
+
+./tools/docker/gcc/docker_run_ubuntu1604.sh ./tools/formatter.sh


### PR DESCRIPTION
`clang-format` formats code differently depending on its version. That causes inconsistent results between the local environment and Travis CI. Here we add a docker image for `clang-format` and remove the validity check on OSX of Travis CI.

## Changes
- We remove the script to check code format on OSX. 
    - Behavior of `clang-format` depends on its version. On OSX with `brew`, it's a bit difficult to control the version of installed packages. In addition to that, we provide a docker image for formatting code which runs on Linux
- Install buildifier and enable checking Bazel code in Travis CI
     - Fixing #14