### PR TITLE
Gaussian quadrature

### DIFF
--- a/docs/quadrature.rst
+++ b/docs/quadrature.rst
@@ -17,6 +17,13 @@ Quadrature methods
    :project: recipe
    :path: ...
 
+.. doxygenfunction:: recipe::quadrature::QuadratureGuassianLegendre5(const Integrand&, const int, const double)
+   :project: recipe
+   :path: ...
+
+.. doxygenfunction:: recipe::quadrature::QuadratureGuassianHermite5(const Integrand&, const int, const double)
+   :project: recipe
+   :path: ...
 
 Integration by substitution
 -----------------------------

--- a/recipe/quadrature/quadrature_gaussian.cc
+++ b/recipe/quadrature/quadrature_gaussian.cc
@@ -1,14 +1,13 @@
 #include "recipe/quadrature/quadrature_gaussian.h"
-#include <iostream>
 #include <array>
+#include <iostream>
 
 namespace recipe {
 namespace quadrature {
 
-double QuadratureGuassianLegendre5(
-    const Integrand integrand,
-    const double left,
-    const double right) {
+double QuadratureGuassianLegendre5(const Integrand integrand, const double left,
+                                   const double right) {
+  // clang-format off
   std::array<double, 5> points = {
     -0.906179845938664,
     -0.5384693101056831,
@@ -23,6 +22,7 @@ double QuadratureGuassianLegendre5(
     0.4786286704993664,
     0.236926885056189,
   };
+  // clang-format on
   double result = 0.0;
   for (int i = 0; i < 5; ++i) {
     result += integrand(points[i]) * weights[i];
@@ -30,10 +30,9 @@ double QuadratureGuassianLegendre5(
   return result;
 }
 
-double QuadratureGuassianLegendre16(
-    const Integrand integrand,
-    const double left,
-    const double right) {
+double QuadratureGuassianLegendre16(const Integrand integrand,
+                                    const double left, const double right) {
+  // clang-format off
   std::array<double, 8> points = {
       0.095012509837637,
       0.281603550779259,
@@ -54,19 +53,19 @@ double QuadratureGuassianLegendre16(
     0.062253523938648,
     0.027152459411754,
   };
+  // clang-format on
 
   double result = 0.0;
   for (int i = 0; i < 8; ++i) {
-    result += (integrand(points[i]) * weights[i]
-               + integrand(-points[i]) * weights[i]);
+    result += (integrand(points[i]) * weights[i] +
+               integrand(-points[i]) * weights[i]);
   }
   return result;
 }
 
-double QuadratureGuassianHermite5(
-    const Integrand integrand,
-    const double left,
-    const double right) {
+double QuadratureGuassianHermite5(const Integrand integrand, const double left,
+                                  const double right) {
+  // clang-format off
   std::array<double, 8> points = {
     0.0,
     0.9585724646138185,
@@ -77,11 +76,12 @@ double QuadratureGuassianHermite5(
     0.3936193231522411,
     0.01995324205904586,
   };
+  // clang-format on
 
   double result = integrand(points[0]) * weights[0];
   for (int i = 1; i < 3; ++i) {
-    result += (integrand(points[i]) * weights[i]
-               + integrand(-points[i]) * weights[i]);
+    result += (integrand(points[i]) * weights[i] +
+               integrand(-points[i]) * weights[i]);
   }
   return result;
 }

--- a/recipe/quadrature/quadrature_gaussian.cc
+++ b/recipe/quadrature/quadrature_gaussian.cc
@@ -66,12 +66,12 @@ double QuadratureGuassianLegendre16(const Integrand integrand,
 double QuadratureGuassianHermite5(const Integrand integrand, const double left,
                                   const double right) {
   // clang-format off
-  std::array<double, 8> points = {
+  std::array<double, 3> points = {
     0.0,
     0.9585724646138185,
     2.020182870456086,
   };
-  std::array<double, 8> weights = {
+  std::array<double, 3> weights = {
     0.9453087204829418,
     0.3936193231522411,
     0.01995324205904586,

--- a/recipe/quadrature/quadrature_gaussian.cc
+++ b/recipe/quadrature/quadrature_gaussian.cc
@@ -1,0 +1,90 @@
+#include "recipe/quadrature/quadrature_gaussian.h"
+#include <iostream>
+#include <array>
+
+namespace recipe {
+namespace quadrature {
+
+double QuadratureGuassianLegendre5(
+    const Integrand integrand,
+    const double left,
+    const double right) {
+  std::array<double, 5> points = {
+    -0.906179845938664,
+    -0.5384693101056831,
+    0.0,
+    0.5384693101056831,
+    0.906179845938664,
+  };
+  std::array<double, 5> weights = {
+    0.236926885056189,
+    0.4786286704993664,
+    0.5688888888888889,
+    0.4786286704993664,
+    0.236926885056189,
+  };
+  double result = 0.0;
+  for (int i = 0; i < 5; ++i) {
+    result += integrand(points[i]) * weights[i];
+  }
+  return result;
+}
+
+double QuadratureGuassianLegendre16(
+    const Integrand integrand,
+    const double left,
+    const double right) {
+  std::array<double, 8> points = {
+      0.095012509837637,
+      0.281603550779259,
+      0.458016777657227,
+      0.617876244402644,
+      0.755404408355003,
+      0.865631202387832,
+      0.944575023073233,
+      0.989400934991650,
+  };
+  std::array<double, 8> weights = {
+    0.189450610455069,
+    0.182603415044924,
+    0.169156519395003,
+    0.149595988816577,
+    0.124628971255534,
+    0.095158511682493,
+    0.062253523938648,
+    0.027152459411754,
+  };
+
+  double result = 0.0;
+  for (int i = 0; i < 8; ++i) {
+    result += (integrand(points[i]) * weights[i]
+               + integrand(-points[i]) * weights[i]);
+  }
+  return result;
+}
+
+double QuadratureGuassianHermite5(
+    const Integrand integrand,
+    const double left,
+    const double right) {
+  std::array<double, 8> points = {
+    0.0,
+    0.9585724646138185,
+    2.020182870456086,
+  };
+  std::array<double, 8> weights = {
+    0.9453087204829418,
+    0.3936193231522411,
+    0.01995324205904586,
+  };
+
+  double result = integrand(points[0]) * weights[0];
+  for (int i = 1; i < 3; ++i) {
+    result += (integrand(points[i]) * weights[i]
+               + integrand(-points[i]) * weights[i]);
+  }
+  return result;
+}
+
+}  // namespace quadrature
+}  // namespace recipe

--- a/recipe/quadrature/quadrature_gaussian.h
+++ b/recipe/quadrature/quadrature_gaussian.h
@@ -1,56 +1,59 @@
 #pragma once
 
-#include "recipe/quadrature/quadrature_gaussian.h"
 #include "recipe/quadrature/quadrature.h"
+#include "recipe/quadrature/quadrature_gaussian.h"
 
 namespace recipe {
 namespace quadrature {
-  ///@brief Gauss-Legendre quadrature with 5 points.
-  /// Weights and abscissas are taken from
-  /// Lowan, A. N., Davids, N., & Levenson, A. (1942). Table of the zeros of the legendre polynomials of order 1-16 and the weight coefficients for gauss’ mechanical quadrature formula. Bulletin of the American Mathematical Society, 48(10), 739–743.
-  ///
-  ///@param integrand
-  ///@param left must be -1.
-  ///@param right must be +1.
-  ///
-  ///@return integrated value
-  ///
-  double QuadratureGuassianLegendre5(const Integrand integrand,
-                                      const double left,
-                                      const double right);
-  ///@brief Gauss-Legendre quadrature with 16 points.
-  /// Weights and abscissas are taken from
-  /// Lowan, A. N., Davids, N., & Levenson, A. (1942). Table of the zeros of the legendre polynomials of order 1-16 and the weight coefficients for gauss’ mechanical quadrature formula. Bulletin of the American Mathematical Society, 48(10), 739–743.
-  ///
-  ///@param integrand
-  ///@param left must be -1.
-  ///@param right must be +1.
-  ///
-  ///@return integrated value.
-  ///
-  ///
-  double QuadratureGuassianLegendre16(const Integrand integrand,
-                                      const double left,
-                                      const double right);
+///@brief Gauss-Legendre quadrature with 5 points.
+/// Weights and abscissas are taken from
+/// Lowan, A. N., Davids, N., & Levenson, A. (1942). Table of the zeros of the
+/// legendre polynomials of order 1-16 and the weight coefficients for gauss’
+/// mechanical quadrature formula. Bulletin of the American Mathematical
+/// Society, 48(10), 739–743.
+///
+///@param integrand
+///@param left must be -1.
+///@param right must be +1.
+///
+///@return integrated value
+///
+double QuadratureGuassianLegendre5(const Integrand integrand, const double left,
+                                   const double right);
+///@brief Gauss-Legendre quadrature with 16 points.
+/// Weights and abscissas are taken from
+/// Lowan, A. N., Davids, N., & Levenson, A. (1942). Table of the zeros of the
+/// legendre polynomials of order 1-16 and the weight coefficients for gauss’
+/// mechanical quadrature formula. Bulletin of the American Mathematical
+/// Society, 48(10), 739–743.
+///
+///@param integrand
+///@param left must be -1.
+///@param right must be +1.
+///
+///@return integrated value.
+///
+///
+double QuadratureGuassianLegendre16(const Integrand integrand,
+                                    const double left, const double right);
 
-  ///@brief Gauss-Hermite quadrature with 5 points. Calculate the following integral given $f$.
-  ///
-  /// $$
-  ///   \\int_{-\\infty}^{\\infty}
-  ///      e^{-x^{2}}
-  ///      f(x)
-  ///   \\ dx
-  /// $$
-  ///
-  ///@param integrand
-  ///@param left must be $-\\infity$.
-  ///@param right must be $+\\infity$.
-  ///
-  ///@return integrated value.
-  double QuadratureGuassianHermite5(const Integrand integrand,
-                                    const double left,
-                                    const double right);
+///@brief Gauss-Hermite quadrature with 5 points. Calculate the following
+/// integral given $f$.
+///
+/// $$
+///   \\int_{-\\infty}^{\\infty}
+///      e^{-x^{2}}
+///      f(x)
+///   \\ dx
+/// $$
+///
+///@param integrand
+///@param left must be $-\\infity$.
+///@param right must be $+\\infity$.
+///
+///@return integrated value.
+double QuadratureGuassianHermite5(const Integrand integrand, const double left,
+                                  const double right);
 
 }  // namespace quadrature
 }  // namespace recipe
-

--- a/recipe/quadrature/quadrature_gaussian.h
+++ b/recipe/quadrature/quadrature_gaussian.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "recipe/quadrature/quadrature_gaussian.h"
+#include "recipe/quadrature/quadrature.h"
+
+namespace recipe {
+namespace quadrature {
+  ///@brief Gauss-Legendre quadrature with 5 points.
+  /// Weights and abscissas are taken from
+  /// Lowan, A. N., Davids, N., & Levenson, A. (1942). Table of the zeros of the legendre polynomials of order 1-16 and the weight coefficients for gauss’ mechanical quadrature formula. Bulletin of the American Mathematical Society, 48(10), 739–743.
+  ///
+  ///@param integrand
+  ///@param left must be -1.
+  ///@param right must be +1.
+  ///
+  ///@return integrated value
+  ///
+  double QuadratureGuassianLegendre5(const Integrand integrand,
+                                      const double left,
+                                      const double right);
+  ///@brief Gauss-Legendre quadrature with 16 points.
+  /// Weights and abscissas are taken from
+  /// Lowan, A. N., Davids, N., & Levenson, A. (1942). Table of the zeros of the legendre polynomials of order 1-16 and the weight coefficients for gauss’ mechanical quadrature formula. Bulletin of the American Mathematical Society, 48(10), 739–743.
+  ///
+  ///@param integrand
+  ///@param left must be -1.
+  ///@param right must be +1.
+  ///
+  ///@return integrated value.
+  ///
+  ///
+  double QuadratureGuassianLegendre16(const Integrand integrand,
+                                      const double left,
+                                      const double right);
+
+  ///@brief Gauss-Hermite quadrature with 5 points. Calculate the following integral given $f$.
+  ///
+  /// $$
+  ///   \\int_{-\\infty}^{\\infty}
+  ///      e^{-x^{2}}
+  ///      f(x)
+  ///   \\ dx
+  /// $$
+  ///
+  ///@param integrand
+  ///@param left must be $-\\infity$.
+  ///@param right must be $+\\infity$.
+  ///
+  ///@return integrated value.
+  double QuadratureGuassianHermite5(const Integrand integrand,
+                                    const double left,
+                                    const double right);
+
+}  // namespace quadrature
+}  // namespace recipe
+

--- a/recipe/quadrature/quadrature_gaussian_test.cc
+++ b/recipe/quadrature/quadrature_gaussian_test.cc
@@ -1,0 +1,55 @@
+#include "recipe/quadrature/quadrature_gaussian.h"
+#include <gtest/gtest.h>
+#include "recipe/core/core.h"
+#include "recipe/test_util/test_util.h"
+
+namespace recipe {
+namespace quadrature {
+
+TEST(QuadratureGuassianLegendre5Test, Example) {
+  Integrand integrand = [](const double x) {
+    return 7.0 * x * x * x - 8.0 * x * x - 3.0 * x + 3.0;
+  };
+  const double left = -1;
+  const double right = 1;
+  const double actual =
+      QuadratureGuassianLegendre5(integrand, left, right);
+
+  const double expect = 2.0 / 3.0;
+  EXPECT_NEAR(expect, actual, 1e-15);
+}
+
+TEST(QuadratureGuassianLegendre16Test, Example) {
+  Integrand integrand = [](const double x) {
+    return 7.0 * x * x * x - 8.0 * x * x - 3.0 * x + 3.0;
+  };
+  const double left = -1;
+  const double right = 1;
+  const double actual =
+      QuadratureGuassianLegendre16(integrand, left, right);
+
+  const double expect = 2.0 / 3.0;
+  EXPECT_NEAR(expect, actual, 1e-12);
+}
+
+// Expectation of 
+TEST(QuadratureGuassianHermite5Test, Example) {
+  Integrand h = [](const double x) {
+    return x;
+  };
+  Integrand integrand = [h](const double x) {
+    const double variance = 1.0;
+    const double mean = 1.0;
+    return h(std::sqrt(2.0 * variance) * x + mean) / std::sqrt(RECIPE_PI);
+  };
+  const double left = -RECIPE_DOUBLE_INF;
+  const double right = RECIPE_DOUBLE_INF;
+  const double actual = QuadratureGuassianHermite5(integrand, left, right);
+
+  const double expect = 1.0;
+  EXPECT_NEAR(expect, actual, 1e-15);
+}
+
+}  // namespace quadrature
+}  // namespace recipe
+

--- a/recipe/quadrature/quadrature_gaussian_test.cc
+++ b/recipe/quadrature/quadrature_gaussian_test.cc
@@ -12,8 +12,7 @@ TEST(QuadratureGuassianLegendre5Test, Example) {
   };
   const double left = -1;
   const double right = 1;
-  const double actual =
-      QuadratureGuassianLegendre5(integrand, left, right);
+  const double actual = QuadratureGuassianLegendre5(integrand, left, right);
 
   const double expect = 2.0 / 3.0;
   EXPECT_NEAR(expect, actual, 1e-15);
@@ -25,18 +24,15 @@ TEST(QuadratureGuassianLegendre16Test, Example) {
   };
   const double left = -1;
   const double right = 1;
-  const double actual =
-      QuadratureGuassianLegendre16(integrand, left, right);
+  const double actual = QuadratureGuassianLegendre16(integrand, left, right);
 
   const double expect = 2.0 / 3.0;
   EXPECT_NEAR(expect, actual, 1e-12);
 }
 
-// Expectation of 
+// Expectation of
 TEST(QuadratureGuassianHermite5Test, Example) {
-  Integrand h = [](const double x) {
-    return x;
-  };
+  Integrand h = [](const double x) { return x; };
   Integrand integrand = [h](const double x) {
     const double variance = 1.0;
     const double mean = 1.0;
@@ -52,4 +48,3 @@ TEST(QuadratureGuassianHermite5Test, Example) {
 
 }  // namespace quadrature
 }  // namespace recipe
-


### PR DESCRIPTION
Implemented 2 Gaussian quadrature methods:
- Gauss-Legendre with 5 and 16 points
- Gauss-Hermite with 5 points

Weights and abscissas for Gauss-Legendre are taken from [1]. Those values for Gauss-Hermite are computed numerically with maxima. We're not sure how much numerical error contains. If we implement special functions in the library, we're able to evaluate more accurate values.
The details of Gauss quadrature algorithms os summarised in [2].

## Reference
- Lowan, A. N., Davids, N., & Levenson, A. (1942). Table of the zeros of the legendre polynomials of order 1-16 and the weight coefficients for gauss’ mechanical quadrature formula. Bulletin of the American Mathematical Society, 48(10), 739–743. https://doi.org/10.1090/S0002-9904-1942-07771-8
- [Gausiaan Quadrature](http://i05nagai.github.io/memorandum/math/numerical_integration/gaussian_quadrature.html)